### PR TITLE
Use externally-provided shared libraries in Python

### DIFF
--- a/python/metatensor-core/CMakeLists.txt
+++ b/python/metatensor-core/CMakeLists.txt
@@ -1,0 +1,53 @@
+# This file allow the python module in metatensor-core to either use an
+# externally-provided version of the shared metatensor library; or to build the
+# code from source and bundle the shared library inside the wheel.
+#
+# The first case is used when distirbuting the code in conda (since we have a
+# separate libmetatensor package), the second one is used everywhere else (for
+# local development builds and for the PyPI distribution).
+
+cmake_minimum_required(VERSION 3.16)
+project(metatensor-python NONE)
+
+option(METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB "Force the usage of an external version of metatensor-core" OFF)
+set(METATENSOR_CORE_SOURCE_DIR "" CACHE PATH "Path to the sources of metatensor-core")
+
+file(REMOVE ${CMAKE_INSTALL_PREFIX}/_external.py)
+
+set(REQUIRED_METATENSOR_VERSION "0.1.10")
+if(${METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB})
+    find_package(metatensor ${REQUIRED_METATENSOR_VERSION} REQUIRED)
+
+    get_target_property(METATENSOR_LOCATION metatensor::shared LOCATION)
+    message(STATUS "Using external metatensor-core v${metatensor_VERSION} at ${METATENSOR_LOCATION}")
+
+    # Get the prefix to use as cmake_prefix_path when trying to load this
+    # version of the library again
+    get_filename_component(METATENSOR_PREFIX "${METATENSOR_LOCATION}" DIRECTORY)
+    get_filename_component(METATENSOR_PREFIX "${METATENSOR_PREFIX}" DIRECTORY)
+
+    file(WRITE ${CMAKE_INSTALL_PREFIX}/_external.py
+        "EXTERNAL_METATENSOR_PATH = \"${METATENSOR_LOCATION}\"\n\n"
+    )
+    file(APPEND ${CMAKE_INSTALL_PREFIX}/_external.py
+        "EXTERNAL_METATENSOR_PREFIX = \"${METATENSOR_PREFIX}\"\n"
+    )
+
+    install(CODE "message(STATUS \"nothing to install\")")
+else()
+    if ("${METATENSOR_CORE_SOURCE_DIR}" STREQUAL "")
+        message(FATAL_ERROR
+            "Missing METATENSOR_CORE_SOURCE_DIR, please specify where to \
+            find the source code for metatensor-core"
+        )
+    endif()
+
+    message(STATUS "Using internal metatensor-core from ${METATENSOR_CORE_SOURCE_DIR}")
+
+    set(BUILD_SHARED_LIBS ON)
+    set(METATENSOR_INSTALL_BOTH_STATIC_SHARED OFF)
+    # strip dynamic library for smaller wheels to download/install
+    set(EXTRA_RUST_FLAGS "-Cstrip=symbols")
+
+    add_subdirectory("${METATENSOR_CORE_SOURCE_DIR}" metatensor-core)
+endif()

--- a/python/metatensor-core/MANIFEST.in
+++ b/python/metatensor-core/MANIFEST.in
@@ -1,6 +1,7 @@
 include metatensor-core-cxx-*.tar.gz
 
 include pyproject.toml
+include CMakeLists.txt
 include AUTHORS
 include LICENSE
 

--- a/python/metatensor-core/metatensor/_c_lib.py
+++ b/python/metatensor-core/metatensor/_c_lib.py
@@ -55,8 +55,8 @@ class LibraryFinder(object):
             if not _compatible_versions(version, __version__):
                 self._cached_dll = None
                 raise RuntimeError(
-                    f"wrong version for libmetatensor, we want {__version__}, "
-                    f"but we got {version} @ '{path}'"
+                    f"wrong version for libmetatensor, we want v{__version__}, "
+                    f"but we got v{version} @ '{path}'"
                 )
 
             # Register the origin used by the Rust API as an external CPU array
@@ -66,6 +66,15 @@ class LibraryFinder(object):
 
 
 def _lib_path():
+    try:
+        # check if we are using an externally-provided version of the shared library
+        from ._external import EXTERNAL_METATENSOR_PATH
+
+        return EXTERNAL_METATENSOR_PATH
+    except ImportError:
+        pass
+
+    # otherwise load from the local installation
     if sys.platform.startswith("darwin"):
         windows = False
         path = os.path.join(_HERE, "lib", "libmetatensor.dylib")

--- a/python/metatensor-core/metatensor/utils.py
+++ b/python/metatensor-core/metatensor/utils.py
@@ -111,7 +111,17 @@ def _to_arguments_parse(context, *args, **kwargs):
     return dtype, device
 
 
-cmake_prefix_path = os.path.join(os.path.dirname(__file__), "lib", "cmake")
-"""
-Path containing the CMake configuration files for the underlying C library
-"""
+try:
+    from ._external import EXTERNAL_METATENSOR_PREFIX
+
+    cmake_prefix_path = EXTERNAL_METATENSOR_PREFIX
+    """
+    Path containing the CMake configuration files for the underlying C library
+    """
+
+except ImportError:
+
+    cmake_prefix_path = os.path.join(os.path.dirname(__file__), "lib", "cmake")
+    """
+    Path containing the CMake configuration files for the underlying C library
+    """

--- a/python/metatensor-torch/CMakeLists.txt
+++ b/python/metatensor-torch/CMakeLists.txt
@@ -1,0 +1,48 @@
+# This file allow the python module in metatensor-torch to either use an
+# externally-provided version of the shared metatensor_torch library; or to
+# build the code from source and bundle the shared library inside the wheel.
+#
+# The first case is used when distirbuting the code in conda (since we have a
+# separate libmetatensor package), the second one is used everywhere else (for
+# local development builds and for the PyPI distribution).
+
+cmake_minimum_required(VERSION 3.16)
+project(metatensor-torch-python NONE)
+
+option(METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB "Force the usage of an external version of metatensor-torch" OFF)
+set(METATENSOR_TORCH_SOURCE_DIR "" CACHE PATH "Path to the sources of metatensor-torch")
+
+file(REMOVE ${CMAKE_INSTALL_PREFIX}/_external.py)
+
+set(REQUIRED_METATENSOR_TORCH_VERSION "0.5.5")
+if(${METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB})
+    find_package(metatensor_torch ${REQUIRED_METATENSOR_TORCH_VERSION} REQUIRED)
+
+    get_target_property(METATENSOR_TORCH_LOCATION metatensor_torch LOCATION)
+    message(STATUS "Using external metatensor-torch v${metatensor_torch_VERSION} at ${METATENSOR_TORCH_LOCATION}")
+
+    # Get the prefix to use as cmake_prefix_path when trying to load this
+    # version of the library again
+    get_filename_component(METATENSOR_TORCH_PREFIX "${METATENSOR_TORCH_LOCATION}" DIRECTORY)
+    get_filename_component(METATENSOR_TORCH_PREFIX "${METATENSOR_TORCH_PREFIX}" DIRECTORY)
+
+    file(WRITE ${CMAKE_INSTALL_PREFIX}/_external.py
+        "EXTERNAL_METATENSOR_TORCH_PATH = \"${METATENSOR_TORCH_LOCATION}\"\n\n"
+    )
+    file(APPEND ${CMAKE_INSTALL_PREFIX}/_external.py
+        "EXTERNAL_METATENSOR_TORCH_PREFIX = \"${METATENSOR_TORCH_PREFIX}\"\n"
+    )
+
+    install(CODE "message(STATUS \"nothing to install\")")
+else()
+    if ("${METATENSOR_TORCH_SOURCE_DIR}" STREQUAL "")
+        message(FATAL_ERROR
+            "Missing METATENSOR_TORCH_SOURCE_DIR, please specify where to \
+            find the source code for metatensor-torch"
+        )
+    endif()
+
+    message(STATUS "Using internal metatensor-torch from ${METATENSOR_TORCH_SOURCE_DIR}")
+
+    add_subdirectory("${METATENSOR_TORCH_SOURCE_DIR}" metatensor-torch)
+endif()

--- a/python/metatensor-torch/MANIFEST.in
+++ b/python/metatensor-torch/MANIFEST.in
@@ -1,4 +1,5 @@
 include pyproject.toml
+include CMakeLists.txt
 include AUTHORS
 include LICENSE
 


### PR DESCRIPTION
This should be everything that need to change on the code side for #402.

The main change is that the `metatensor-core` and `metatensor-torch` python packages now have their own CMakeFile.txt that handles either finding a pre-existing shared library or building one from scratch.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/1895733445.zip)

<!-- download-section Build Python wheels end -->