### PR TITLE
Release metatensor-rust v0.1.6

### DIFF
--- a/rust/metatensor/CHANGELOG.md
+++ b/rust/metatensor/CHANGELOG.md
@@ -15,11 +15,14 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.6](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.1.6) - 2024-09-10
+
 ### Added
 
 - Added support for serialization of TensorBlock with `TensorBlock::load`,
   `TensorBlock::load_buffer`, `TensorBlock::save`, `TensorBlock::save_buffer`
   and the corresponding functions in `metatensor::io`.
+- `Labels::select` function, to sub-select labels entries.
 
 ## [Version 0.1.5](https://github.com/metatensor/metatensor/releases/tag/metatensor-rust-v0.1.5) - 2024-03-12
 

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.65"
 
@@ -14,7 +14,7 @@ license = "BSD-3-Clause"
 bench = false
 
 [dependencies]
-metatensor-sys = {version = "0.1", path="../metatensor-sys"}
+metatensor-sys = {version = "0.1.10", path="../metatensor-sys"}
 
 once_cell = "1"
 smallvec = {version = "1", features = ["union"]}


### PR DESCRIPTION
This brings the changes in `-core` v0.1.10 to Rust.


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/1915633664.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/1915769273.zip)

<!-- download-section Build Python wheels end -->