### PR TITLE
Add PBCs to the `System` class

### DIFF
--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -6,18 +6,19 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ## [Unreleased](https://github.com/metatensor/metatensor/)
 
-<!-- Possible sections:
-
 ### Added
 
 ### Fixed
 
 ### Changed
 
+- the `System` class now supports boundary conditions along some axes but not others. This is implemented
+  via a new `pbc` attribute. Any non-periodic dimension in a `System` must have the corrresponding cell
+  vector set to zero.
+
 ### Deprecated
 
 ### Removed
--->
 
 ## [Version 0.5.5](https://github.com/metatensor/metatensor/releases/tag/metatensor-torch-v0.5.5) - 2024-09-03
 

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -6,19 +6,22 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ## [Unreleased](https://github.com/metatensor/metatensor/)
 
-### Added
+<!-- Possible sections for each package:
 
-### Fixed
+#### Added
+
+#### Fixed
+
+#### Changed
+
+#### Removed
+-->
 
 ### Changed
 
 - the `System` class now supports boundary conditions along some axes but not others. This is implemented
   via a new `pbc` attribute. Any non-periodic dimension in a `System` must have the corrresponding cell
   vector set to zero.
-
-### Deprecated
-
-### Removed
 
 ## [Version 0.5.5](https://github.com/metatensor/metatensor/releases/tag/metatensor-torch-v0.5.5) - 2024-09-03
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
@@ -151,9 +151,9 @@ public:
     ///        cell of the system. Each row should be one of the bounding box
     ///        vector; and columns should contain the x, y, and z components of
     ///        these vectors (i.e. the cell should be given in row-major order).
-    ///        Systems are assumed to obey periodic boundary conditions,
-    ///        non-periodic systems should set the cell to 0.
-    SystemHolder(torch::Tensor types, torch::Tensor positions, torch::Tensor cell);
+    /// @param pbc 1D tensor of 3 boolean values, indicating if the system is
+    ///        periodic in the x, y, and z directions, respectively.
+    SystemHolder(torch::Tensor types, torch::Tensor positions, torch::Tensor cell, torch::Tensor pbc);
     ~SystemHolder() override = default;
 
     /// Get the particle types for all particles in the system.

--- a/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
@@ -152,7 +152,7 @@ public:
     ///        vector; and columns should contain the x, y, and z components of
     ///        these vectors (i.e. the cell should be given in row-major order).
     /// @param pbc 1D tensor of 3 boolean values, indicating if the system is
-    ///        periodic in the x, y, and z directions, respectively.
+    ///        periodic along the directions defined by cell axes `a`, `b` and `c`, respectively.
     SystemHolder(torch::Tensor types, torch::Tensor positions, torch::Tensor cell, torch::Tensor pbc);
     ~SystemHolder() override = default;
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
@@ -180,6 +180,14 @@ public:
     /// Set cell for the system
     void set_cell(torch::Tensor cell);
 
+    /// Periodic boundary conditions for the system.
+    torch::Tensor pbc() const {
+        return pbc_;
+    }
+
+    /// Set periodic boundary conditions for the system
+    void set_pbc(torch::Tensor pbc);
+
     /// Get the device used by all the data in this `System`
     torch::Device device() const {
         return this->types_.device();
@@ -270,6 +278,7 @@ private:
     torch::Tensor types_;
     torch::Tensor positions_;
     torch::Tensor cell_;
+    torch::Tensor pbc_;
 
     std::map<NeighborListOptions, TorchTensorBlock, nl_options_compare> neighbors_;
     std::unordered_map<std::string, TorchTensorBlock> data_;

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -575,6 +575,17 @@ void SystemHolder::set_pbc(torch::Tensor pbc) {
         );
     }
 
+    // if the pbcs are False along any directions, we check that the
+    // corresponding cell vectors are zero
+    if (pbc.device().str() != "meta") {  // skip this check for meta tensors
+        auto cell_where_pbc_is_false = cell_.index({pbc == false});
+        if (!torch::all(cell_where_pbc_is_false == 0.0).item<bool>()) {
+            C10_THROW_ERROR(ValueError,
+                "if `pbc` is False along any direction, the corresponding cell vector must be zero"
+            );
+        }
+    }
+
     this->pbc_ = std::move(pbc);
 }
 

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -433,9 +433,9 @@ SystemHolder::SystemHolder(torch::Tensor types, torch::Tensor positions, torch::
         );
     }
 
-    // if the pbcs are False along any directions, we check that the
+    // if the PBC are False along any directions, we check that the
     // corresponding cell vectors are zero
-    if (pbc_.device().str() != "meta") {  // skip this check for meta tensors
+    if (!pbc_.device().is_meta()) {
         auto cell_where_pbc_is_false = cell_.index({pbc_ == false});
         if (!torch::all(cell_where_pbc_is_false == 0.0).item<bool>()) {
             C10_THROW_ERROR(ValueError,
@@ -575,9 +575,10 @@ void SystemHolder::set_pbc(torch::Tensor pbc) {
         );
     }
 
-    // if the pbcs are False along any directions, we check that the
+
+    // if the PBC are False along any directions, we check that the
     // corresponding cell vectors are zero
-    if (pbc.device().str() != "meta") {  // skip this check for meta tensors
+    if (!pbc_.device().is_meta()) {
         auto cell_where_pbc_is_false = cell_.index({pbc == false});
         if (!torch::all(cell_where_pbc_is_false == 0.0).item<bool>()) {
             C10_THROW_ERROR(ValueError,

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -435,11 +435,13 @@ SystemHolder::SystemHolder(torch::Tensor types, torch::Tensor positions, torch::
 
     // if the pbcs are False along any directions, we check that the
     // corresponding cell vectors are zero
-    auto cell_where_pbc_is_false = cell_.index({pbc_ == false});
-    if (!torch::all(cell_where_pbc_is_false == 0.0).item<bool>()) {
-        C10_THROW_ERROR(ValueError,
-            "if `pbc` is False along any direction, the corresponding cell vector must be zero"
-        );
+    if (pbc_.device().str() != "meta") {  // skip this check for meta tensors
+        auto cell_where_pbc_is_false = cell_.index({pbc_ == false});
+        if (!torch::all(cell_where_pbc_is_false == 0.0).item<bool>()) {
+            C10_THROW_ERROR(ValueError,
+                "if `pbc` is False along any direction, the corresponding cell vector must be zero"
+            );
+        }
     }
 }
 
@@ -609,7 +611,7 @@ System SystemHolder::to(
             /*memory_format*/ torch::MemoryFormat::Preserve
         ),
         this->pbc().to(
-            dtype,
+            /*dtype*/ torch::nullopt,
             /*layout*/ torch::nullopt,
             device,
             /*pin_memory*/ torch::nullopt,

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -544,6 +544,38 @@ void SystemHolder::set_cell(torch::Tensor cell) {
     this->cell_ = std::move(cell);
 }
 
+void SystemHolder::set_pbc(torch::Tensor pbc) {
+    if (pbc.device() != this->device()) {
+        C10_THROW_ERROR(ValueError,
+            "new `pbc` must be on the same device as existing data, got " +
+            pbc.device().str() + " and " + this->device().str()
+        );
+    }
+
+    if (pbc.scalar_type() != torch::kBool) {
+        C10_THROW_ERROR(ValueError,
+            "new `pbc` must be a tensor of booleans, got " +
+            scalar_type_name(pbc.scalar_type()) + " instead"
+        );
+    }
+
+    if (pbc.sizes().size() != 1) {
+        C10_THROW_ERROR(ValueError,
+            "new `pbc` must be a 1 dimensional tensor, got a tensor with " +
+            std::to_string(pbc.sizes().size()) + " dimensions"
+        );
+    }
+
+    if (pbc.size(0) != 3) {
+        C10_THROW_ERROR(ValueError,
+            "new `pbc` must contain 3 entries, got a tensor with " +
+            std::to_string(pbc.size(0)) + " values"
+        );
+    }
+
+    this->pbc_ = std::move(pbc);
+}
+
 System SystemHolder::to(
     torch::optional<torch::Dtype> dtype,
     torch::optional<torch::Device> device

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -362,6 +362,7 @@ TORCH_LIBRARY(metatensor, m) {
         .def_property("types", &SystemHolder::types, &SystemHolder::set_types)
         .def_property("positions", &SystemHolder::positions, &SystemHolder::set_positions)
         .def_property("cell", &SystemHolder::cell, &SystemHolder::set_cell)
+        .def_property("pbc", &SystemHolder::pbc, &SystemHolder::set_pbc)
         .def("__len__", &SystemHolder::size)
         .def("__str__", &SystemHolder::str)
         .def("__repr__", &SystemHolder::str)

--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -356,8 +356,8 @@ TORCH_LIBRARY(metatensor, m) {
 
     m.class_<SystemHolder>("System")
         .def(
-            torch::init<torch::Tensor, torch::Tensor, torch::Tensor>(), DOCSTRING,
-            {torch::arg("types"), torch::arg("positions"), torch::arg("cell")}
+            torch::init<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>(), DOCSTRING,
+            {torch::arg("types"), torch::arg("positions"), torch::arg("cell"), torch::arg("pbc")}
         )
         .def_property("types", &SystemHolder::types, &SystemHolder::set_types)
         .def_property("positions", &SystemHolder::positions, &SystemHolder::set_positions)

--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -529,7 +529,7 @@ def _compute_ase_neighbors(atoms, options, dtype, device):
 
 
 def _ase_to_torch_data(atoms, dtype, device):
-    """Get the positions, cell and pbcs from ASE atoms as torch tensors"""
+    """Get the positions, cell and pbc from ASE atoms as torch tensors"""
 
     types = torch.from_numpy(atoms.numbers).to(dtype=torch.int32, device=device)
     positions = torch.from_numpy(atoms.positions).to(dtype=dtype, device=device)

--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -205,10 +205,10 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
         :param outputs: outputs of the model that should be predicted
         :param selected_atoms: subset of atoms on which to run the calculation
         """
-        types, positions, cell = _ase_to_torch_data(
+        types, positions, cell, pbc = _ase_to_torch_data(
             atoms=atoms, dtype=self._dtype, device=self._device
         )
-        system = System(types, positions, cell)
+        system = System(types, positions, cell, pbc)
 
         # Compute the neighbors lists requested by the model using ASE NL
         for options in self._model.requested_neighbor_lists():
@@ -282,7 +282,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
                         "does not support it"
                     )
 
-            types, positions, cell = _ase_to_torch_data(
+            types, positions, cell, pbc = _ase_to_torch_data(
                 atoms=atoms, dtype=self._dtype, device=self._device
             )
 
@@ -311,7 +311,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
 
         with record_function("ASECalculator::compute_neighbors"):
             # convert from ase.Atoms to metatensor.torch.atomistic.System
-            system = System(types, positions, cell)
+            system = System(types, positions, cell, pbc)
 
             for options in self._model.requested_neighbor_lists():
                 neighbors = _compute_ase_neighbors(
@@ -529,22 +529,16 @@ def _compute_ase_neighbors(atoms, options, dtype, device):
 
 
 def _ase_to_torch_data(atoms, dtype, device):
-    """Get the positions and cell from ASE atoms as torch tensors"""
+    """Get the positions, cell and pbcs from ASE atoms as torch tensors"""
 
     types = torch.from_numpy(atoms.numbers).to(dtype=torch.int32, device=device)
     positions = torch.from_numpy(atoms.positions).to(dtype=dtype, device=device)
+    cell = torch.zeros((3, 3), dtype=dtype, device=device)
+    pbc = torch.tensor(atoms.pbc, dtype=torch.bool, device=device)
 
-    if np.all(atoms.pbc):
-        cell = torch.from_numpy(atoms.cell[:]).to(dtype=dtype, device=device)
-    elif np.any(atoms.pbc):
-        raise ValueError(
-            f"partial PBC ({atoms.pbc}) are not currently supported in "
-            "metatensor atomistic models"
-        )
-    else:
-        cell = torch.zeros((3, 3), dtype=dtype, device=device)
+    cell[pbc] = torch.tensor(atoms.cell[atoms.pbc], dtype=dtype, device=device)
 
-    return types, positions, cell
+    return types, positions, cell, pbc
 
 
 def _full_3x3_to_voigt_6_stress(stress):

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -715,6 +715,7 @@ def _convert_systems_units(
             types=system.types,
             positions=conversion * system.positions,
             cell=conversion * system.cell,
+            pbc=system.pbc,
         )
 
         # also update the neighbors list distances

--- a/python/metatensor-torch/metatensor/torch/atomistic/systems_to_torch.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/systems_to_torch.py
@@ -1,7 +1,5 @@
-import warnings
 from typing import List, Optional, Union
 
-import numpy as np
 import torch
 
 from . import System
@@ -105,30 +103,12 @@ def _system_to_torch(
         device=device,
     )
 
-    if np.all(system.pbc):
-        cell = torch.tensor(
-            system.cell[:],
-            requires_grad=cell_requires_grad,
-            dtype=dtype,
-            device=device,
-        )
-    elif not np.any(system.pbc):
-        if system.cell is not None and not np.all(system.cell == 0):
-            warnings.warn(
-                "A conversion to `System` was requested for an `ase.Atoms` object "
-                "with non-zero cell vectors but no periodic boundary conditions. "
-                "The cell vectors will be set to zero.",
-                stacklevel=2,
-            )
-        cell = torch.zeros(
-            (3, 3), requires_grad=cell_requires_grad, dtype=dtype, device=device
-        )
-    else:
-        raise ValueError(
-            "The `metatensor.torch.atomistic.System` class does not support "
-            "systems with mixed periodic and non-periodic dimensions."
-        )
+    cell = torch.zeros((3, 3), dtype=dtype, device=device)
+
+    pbc = torch.tensor(system.pbc, dtype=torch.bool, device=device)
+
+    cell[pbc] = torch.tensor(system.cell[system.pbc], dtype=dtype, device=device)
 
     types = torch.tensor(system.numbers, device=device, dtype=torch.int32)
 
-    return System(positions=positions, cell=cell, types=types)
+    return System(positions=positions, cell=cell, types=types, pbcs=pbc)

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -306,6 +306,7 @@ def _read_neighbor_check(path):
         types=torch.tensor([1] * positions.shape[0], dtype=torch.int32),
         positions=positions,
         cell=torch.tensor(data["system"]["cell"], dtype=dtype),
+        pbc=torch.tensor([True, True, True]),
     )
 
     options = NeighborListOptions(

--- a/python/metatensor-torch/tests/atomistic/examples.py
+++ b/python/metatensor-torch/tests/atomistic/examples.py
@@ -36,6 +36,7 @@ def test_export_atomistic_model(tmp_path):
         types=torch.tensor([1]),
         positions=torch.tensor([[1.0, 1, 1]], dtype=torch.float64, requires_grad=True),
         cell=torch.zeros([3, 3], dtype=torch.float64),
+        pbc=torch.tensor([False, False, False]),
     )
 
     outputs = {

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -159,7 +159,7 @@ def test_neighbor_autograd_errors():
         torch.from_numpy(atoms.numbers).to(torch.int32),
         positions.to(torch.float32),
         cell.to(torch.float32),
-        pbcs=torch.tensor([True, True, True]),
+        pbc=torch.tensor([True, True, True]),
     )
     with pytest.raises(ValueError, match=message):
         register_autograd_neighbors(system, neighbors, check_consistency=True)
@@ -169,7 +169,7 @@ def test_neighbor_autograd_errors():
         torch.from_numpy(atoms.numbers).to(torch.int32).to(torch.device("meta")),
         positions.to(torch.device("meta")),
         cell.to(torch.device("meta")),
-        pbcs=torch.tensor([True, True, True]).to(torch.device("meta")),
+        pbc=torch.tensor([True, True, True]).to(torch.device("meta")),
     )
     with pytest.raises(ValueError, match=message):
         register_autograd_neighbors(system, neighbors, check_consistency=True)

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -77,7 +77,10 @@ def test_neighbors_autograd():
         )
 
         system = System(
-            torch.from_numpy(atoms.numbers).to(torch.int32), positions, cell
+            torch.from_numpy(atoms.numbers).to(torch.int32),
+            positions,
+            cell,
+            pbc=torch.tensor([True, True, True]),
         )
         register_autograd_neighbors(system, neighbors, check_consistency=True)
 
@@ -117,7 +120,12 @@ def test_neighbor_autograd_errors():
     neighbors = _compute_ase_neighbors(
         atoms, options, dtype=torch.float64, device="cpu"
     )
-    system = System(torch.from_numpy(atoms.numbers).to(torch.int32), positions, cell)
+    system = System(
+        torch.from_numpy(atoms.numbers).to(torch.int32),
+        positions,
+        cell,
+        pbc=torch.tensor([True, True, True]),
+    )
     register_autograd_neighbors(system, neighbors)
 
     message = (
@@ -151,6 +159,7 @@ def test_neighbor_autograd_errors():
         torch.from_numpy(atoms.numbers).to(torch.int32),
         positions.to(torch.float32),
         cell.to(torch.float32),
+        pbcs=torch.tensor([True, True, True]),
     )
     with pytest.raises(ValueError, match=message):
         register_autograd_neighbors(system, neighbors, check_consistency=True)
@@ -160,6 +169,7 @@ def test_neighbor_autograd_errors():
         torch.from_numpy(atoms.numbers).to(torch.int32).to(torch.device("meta")),
         positions.to(torch.device("meta")),
         cell.to(torch.device("meta")),
+        pbcs=torch.tensor([True, True, True]).to(torch.device("meta")),
     )
     with pytest.raises(ValueError, match=message):
         register_autograd_neighbors(system, neighbors, check_consistency=True)

--- a/python/metatensor-torch/tests/atomistic/outputs.py
+++ b/python/metatensor-torch/tests/atomistic/outputs.py
@@ -20,6 +20,7 @@ def system():
         types=torch.tensor([1, 2, 3]),
         positions=torch.tensor([[1, 1, 1], [2, 2, 2], [3, 3, 3]], dtype=torch.float64),
         cell=torch.zeros([3, 3], dtype=torch.float64),
+        pbc=torch.tensor([False, False, False]),
     )
 
 

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -159,8 +159,8 @@ def test_data_validation(types, positions, cell, pbc):
 
     # ===== types checks ===== #
     message = (
-        "`types`, `positions`, and `cell` must be on the same device, "
-        "got meta, cpu, and cpu"
+        "`types`, `positions`, `cell`, and `pbc` must be on the same "
+        "device, got meta, cpu, cpu, and cpu"
     )
     with pytest.raises(ValueError, match=message):
         System(types.to(device="meta"), positions, cell, pbc)
@@ -191,8 +191,8 @@ def test_data_validation(types, positions, cell, pbc):
 
     # ===== positions checks ===== #
     message = (
-        "`types`, `positions`, and `cell` must be on the same device, "
-        "got cpu, meta, and cpu"
+        "`types`, `positions`, `cell`, and `pbc` must be on the same device, "
+        "got cpu, meta, cpu, and cpu"
     )
     with pytest.raises(ValueError, match=message):
         System(types, positions.to(device="meta"), cell, pbc)
@@ -244,8 +244,8 @@ def test_data_validation(types, positions, cell, pbc):
 
     # ===== cell checks ===== #
     message = (
-        "`types`, `positions`, and `cell` must be on the same device, "
-        "got cpu, cpu, and meta"
+        "`types`, `positions`, `cell`, and `pbc` must be on the same device, "
+        "got cpu, cpu, meta, and cpu"
     )
     with pytest.raises(ValueError, match=message):
         System(types, positions, cell.to(device="meta"), pbc)

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -25,8 +25,13 @@ def cell():
 
 
 @pytest.fixture
-def system(types, positions, cell):
-    return System(types=types, positions=positions, cell=cell)
+def pbc():
+    return torch.tensor([True, True, True])
+
+
+@pytest.fixture
+def system(types, positions, cell, pbc):
+    return System(types=types, positions=positions, cell=cell, pbc=pbc)
 
 
 @pytest.fixture
@@ -53,12 +58,13 @@ def neighbors():
     )
 
 
-def test_system(types, positions, cell, neighbors):
-    system = System(types, positions, cell)
+def test_system(types, positions, cell, pbc, neighbors):
+    system = System(types, positions, cell, pbc)
 
     assert torch.all(system.types == types)
     assert torch.all(system.positions == positions)
     assert torch.all(system.cell == cell)
+    assert torch.all(system.pbc == pbc)
 
     expected = "System with 8 atoms, periodic cell: [12, 0, 0, 0, 12.3, 0, 0, 0, 10]"
     assert str(system) == expected
@@ -66,7 +72,12 @@ def test_system(types, positions, cell, neighbors):
         # custom __repr__ definitions are only available since torch 2.1
         assert repr(system) == expected
 
-    system = System(types, positions, cell=torch.zeros_like(cell))
+    system = System(
+        types,
+        positions,
+        cell=torch.zeros_like(cell),
+        pbc=torch.tensor([False, False, False]),
+    )
     expected = "System with 8 atoms, non periodic"
     assert str(system) == expected
     if version.parse(torch.__version__) >= version.parse("2.1"):
@@ -142,9 +153,9 @@ def test_custom_data(system):
     assert metatensor.torch.equal_block(system.get_data("data-name"), new_data)
 
 
-def test_data_validation(types, positions, cell):
+def test_data_validation(types, positions, cell, pbc):
     # this should run without error:
-    system = System(types, positions, cell)
+    system = System(types, positions, cell, pbc)
 
     # ===== types checks ===== #
     message = (
@@ -152,7 +163,7 @@ def test_data_validation(types, positions, cell):
         "got meta, cpu, and cpu"
     )
     with pytest.raises(ValueError, match=message):
-        System(types.to(device="meta"), positions, cell)
+        System(types.to(device="meta"), positions, cell, pbc)
 
     message = (
         "new `types` must be on the same device as existing data, got meta and cpu"
@@ -162,7 +173,7 @@ def test_data_validation(types, positions, cell):
 
     message = "`types` must be a 1 dimensional tensor, got a tensor with 2 dimensions"
     with pytest.raises(ValueError, match=message):
-        System(types.reshape(-1, 1), positions, cell)
+        System(types.reshape(-1, 1), positions, cell, pbc)
 
     message = (
         "new `types` must be a 1 dimensional tensor, got a tensor with 2 dimensions"
@@ -172,7 +183,7 @@ def test_data_validation(types, positions, cell):
 
     message = "`types` must be a tensor of integers, got torch.float64 instead"
     with pytest.raises(ValueError, match=message):
-        System(types.to(dtype=torch.float64), positions, cell)
+        System(types.to(dtype=torch.float64), positions, cell, pbc)
 
     message = "`types` must be a tensor of integers, got torch.float64 instead"
     with pytest.raises(ValueError, match=message):
@@ -184,7 +195,7 @@ def test_data_validation(types, positions, cell):
         "got cpu, meta, and cpu"
     )
     with pytest.raises(ValueError, match=message):
-        System(types, positions.to(device="meta"), cell)
+        System(types, positions.to(device="meta"), cell, pbc)
 
     message = (
         "new `positions` must be on the same device as existing data, got meta and cpu"
@@ -196,7 +207,7 @@ def test_data_validation(types, positions, cell):
         "`positions` must be a 2 dimensional tensor, got a tensor with 3 dimensions"
     )
     with pytest.raises(ValueError, match=message):
-        System(types, positions.reshape(1, -1, 3), cell)
+        System(types, positions.reshape(1, -1, 3), cell, pbc)
 
     message = (
         "new `positions` must be a 2 dimensional tensor, got a tensor with 3 dimensions"
@@ -209,7 +220,7 @@ def test_data_validation(types, positions, cell):
         "got a tensor with shape \\[8, 3\\]"
     )
     with pytest.raises(ValueError, match=message):
-        System(torch.hstack([types, types]), positions, cell)
+        System(torch.hstack([types, types]), positions, cell, pbc)
 
     message = (
         "`positions` must be a \\(len\\(types\\) x 3\\) tensor, "
@@ -222,7 +233,7 @@ def test_data_validation(types, positions, cell):
         "`positions` must be a tensor of floating point data, got torch.int32 instead"
     )
     with pytest.raises(ValueError, match=message):
-        System(types, positions.to(dtype=torch.int32), cell)
+        System(types, positions.to(dtype=torch.int32), cell, pbc)
 
     message = (
         "new `positions` must have the same dtype as existing data, "
@@ -237,7 +248,7 @@ def test_data_validation(types, positions, cell):
         "got cpu, cpu, and meta"
     )
     with pytest.raises(ValueError, match=message):
-        System(types, positions, cell.to(device="meta"))
+        System(types, positions, cell.to(device="meta"), pbc)
 
     message = "new `cell` must be on the same device as existing data, got meta and cpu"
     with pytest.raises(ValueError, match=message):
@@ -245,7 +256,7 @@ def test_data_validation(types, positions, cell):
 
     message = "`cell` must be a 2 dimensional tensor, got a tensor with 3 dimensions"
     with pytest.raises(ValueError, match=message):
-        System(types, positions, cell.reshape(3, 1, 3))
+        System(types, positions, cell.reshape(3, 1, 3), pbc)
 
     message = (
         "new `cell` must be a 2 dimensional tensor, got a tensor with 3 dimensions"
@@ -255,7 +266,7 @@ def test_data_validation(types, positions, cell):
 
     message = "`cell` must be a \\(3 x 3\\) tensor, got a tensor with shape \\[6, 3\\]"
     with pytest.raises(ValueError, match=message):
-        System(types, positions, torch.vstack([cell, cell]))
+        System(types, positions, torch.vstack([cell, cell]), pbc)
 
     message = (
         "new `cell` must be a \\(3 x 3\\) tensor, got a tensor with shape \\[6, 3\\]"
@@ -268,7 +279,7 @@ def test_data_validation(types, positions, cell):
         "got torch.int32 and torch.float32"
     )
     with pytest.raises(ValueError, match=message):
-        System(types, positions, cell.to(dtype=torch.int32))
+        System(types, positions, cell.to(dtype=torch.int32), pbc)
 
     message = (
         "new `cell` must have the same dtype as existing data, "

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -477,3 +477,17 @@ def test_to(system, neighbors):
 @torch.jit.script
 def check_dtype(system: System, dtype: torch.dtype):
     assert system.dtype == dtype
+
+
+def test_partial_pbc():
+    with pytest.raises(
+        ValueError,
+        match="if `pbc` is False along any direction, "
+        "the corresponding cell vector must be zero",
+    ):
+        System(
+            torch.tensor([1]),
+            torch.tensor([[1.0, 1.0, 1.0]]),
+            torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+            pbc=torch.tensor([True, False, True]),
+        )


### PR DESCRIPTION
This PR implements PBCs in the `System` class, allowing for structures where only some of the dimensions have PBCs.

A few questions:
- should we have default arguments (most likely `True, True, True` for backward compatibility)?
- is the strategy to ignore the cell if the PBCs are False? Or do we require it to have some all-zero rows if PBCs are False?


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2004641647.zip)

<!-- download-section Documentation end -->