### PR TITLE
Bump minimal Rust version to 1.74

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -48,7 +48,7 @@ jobs:
           # check the build on a stock Ubuntu 20.04, which uses cmake 3.16, and
           # with our minimal supported rust version
           - os: ubuntu-20.04
-            rust-version: 1.65
+            rust-version: 1.74
             container: ubuntu:20.04
             rust-target: x86_64-unknown-linux-gnu
             cargo-build-flags: --features=rayon

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ on metatensor:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.65 to build metatensor.
+  1.74 to build metatensor.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.9.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,6 +17,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
+### Changed
+
+- The code now requires Rustc v1.74 to build.
+
 ### metatensor-core Julia
 
 #### Added

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "metatensor-core"
 version = "0.1.10"
 edition = "2021"
 publish = false
-rust-version = "1.65"
+rust-version = "1.74"
 exclude = [
     "tests"
 ]
@@ -14,8 +14,7 @@ name = "metatensor"
 bench = false
 
 [dependencies]
-# ahash 0.8.7 is the last version supporting rustc 1.65
-ahash = { version = "=0.8.7", default-features = false, features = ["std"]}
+ahash = { version = "0.8", default-features = false, features = ["std"]}
 hashbrown = "0.14"
 indexmap = "2"
 once_cell = "1"
@@ -27,11 +26,8 @@ num-traits = {version = "0.2", default-features = false}
 zip = {version = "0.6", default-features = false, features = ["deflate"]}
 
 [build-dependencies]
-cbindgen = { version = "0.26", default-features = false }
+cbindgen = { version = "0.27", default-features = false }
 
 [dev-dependencies]
-which = "5"
+which = "6"
 lazy_static = "1"
-
-# This is the last version supporting rustc 1.65
-home = "=0.5.5"

--- a/metatensor-core/build.rs
+++ b/metatensor-core/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::field_reassign_with_default)]
+
 use std::path::PathBuf;
 
 fn main() {

--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -1166,7 +1166,7 @@ mts_status_t mts_tensormap_save_buffer(uint8_t **buffer,
                                        const struct mts_tensormap_t *tensor);
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
 
-#endif /* METATENSOR_H */
+#endif  /* METATENSOR_H */

--- a/metatensor-torch/Cargo.toml
+++ b/metatensor-torch/Cargo.toml
@@ -3,13 +3,11 @@ name = "metatensor-torch"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version = "1.74"
 
 [lib]
 path = "lib.rs"
 
 [dev-dependencies]
-which = "5"
+which = "6"
 lazy_static = "1"
-
-# This is the last version supporting rustc 1.65
-home = "=0.5.5"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,13 +3,10 @@ name = "metatensor-python"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.65"
+rust-version = "1.74"
 
 [lib]
 path = "lib.rs"
 
 [dev-dependencies]
-which = "5"
-
-# This is the last version supporting rustc 1.65
-home = "=0.5.5"
+which = "6"

--- a/python/metatensor-torch/tests/atomistic/metadata.py
+++ b/python/metatensor-torch/tests/atomistic/metadata.py
@@ -253,7 +253,7 @@ def test_with_extra_metadata(tmpdir):
 
     torch.save(metadata, str(tmpdir.join("metadata.pt")))
 
-    if version.parse(torch.__version__) <= version.parse("1.12"):
+    if version.parse(torch.__version__) >= version.parse("1.13"):
         loaded_metadata = torch.load(
             str(tmpdir.join("metadata.pt")), weights_only=False
         )

--- a/python/metatensor-torch/tests/serialization.py
+++ b/python/metatensor-torch/tests/serialization.py
@@ -128,7 +128,7 @@ def test_pickle(tmpdir, tensor_path):
 
     with tmpdir.as_cwd():
         torch.save(tensor, tmpfile)
-        if version.parse(torch.__version__) <= version.parse("1.12"):
+        if version.parse(torch.__version__) >= version.parse("1.13"):
             loaded = torch.load(tmpfile, weights_only=False)
         else:
             loaded = torch.load(tmpfile)
@@ -199,7 +199,7 @@ def test_pickle_block(tmpdir, block_path):
     with tmpdir.as_cwd():
         torch.save(block, tmpfile)
 
-        if version.parse(torch.__version__) <= version.parse("1.12"):
+        if version.parse(torch.__version__) >= version.parse("1.13"):
             loaded = torch.load(tmpfile, weights_only=False)
         else:
             loaded = torch.load(tmpfile)
@@ -257,7 +257,7 @@ def test_pickle_labels(tmpdir, labels_path):
     with tmpdir.as_cwd():
         torch.save(labels, tmpfile)
 
-        if version.parse(torch.__version__) <= version.parse("1.12"):
+        if version.parse(torch.__version__) >= version.parse("1.13"):
             loaded = torch.load(tmpfile, weights_only=False)
         else:
             loaded = torch.load(tmpfile)

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "metatensor-sys"
 # This should be kept in sync with metatensor-core version number
 version = "0.1.10"
 edition = "2021"
+rust-version = "1.74"
 
 description = "Bindings to the metatensor C library"
 readme = "README.md"
@@ -27,8 +28,4 @@ static = []
 [build-dependencies]
 # we want a recent version of the cmake crate
 cmake = "0.1.49"
-which = "5"
-
-# these are the last version supporting rustc 1.65
-home = "=0.5.5"
-cc = "=1.0.105"
+which = "6"

--- a/rust/metatensor/Cargo.toml
+++ b/rust/metatensor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "metatensor"
 version = "0.1.6"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.74"
 
 description = "Self-describing sparse tensor data format for atomistic machine learning and beyond"
 readme = "../../README.md"
@@ -18,7 +18,7 @@ metatensor-sys = {version = "0.1.10", path="../metatensor-sys"}
 
 once_cell = "1"
 smallvec = {version = "1", features = ["union"]}
-ndarray = {version = "0.15"}
+ndarray = {version = "0.16"}
 rayon = {version = "1", optional = true}
 
 

--- a/rust/metatensor/src/lib.rs
+++ b/rust/metatensor/src/lib.rs
@@ -28,7 +28,7 @@
 #![allow(clippy::unreadable_literal, clippy::option_if_let_else, clippy::module_name_repetitions)]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::missing_safety_doc)]
 #![allow(clippy::similar_names, clippy::borrow_as_ptr, clippy::uninlined_format_args)]
-#![allow(clippy::thread_local_initializer_can_be_made_const)]
+#![allow(clippy::missing_const_for_thread_local)]
 
 pub use metatensor_sys as c_api;
 


### PR DESCRIPTION
This was prompted by a test failure in https://github.com/Luthaf/rascaline/pull/328. This allows us to update a bunch of dependencies to newer versions.

The version of rustc available through APT is 1.75 for ubuntu from 20.04 to 24.04, so this should not change anything for people using rustc from there.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/1971205940.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/1971339516.zip)

<!-- download-section Build Python wheels end -->