### PR TITLE
Add the right permissions to CI making the releases

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -343,6 +343,8 @@ jobs:
     name: Merge and release wheels/sdists
     needs: [build-core-wheels, merge-torch-wheels, build-others]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Download metatensor-core wheels
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Creating the release failed for `metatensor-operation-v0.2.4`: https://github.com/metatensor/metatensor/actions/runs/11295315675/job/31419476194

I'm not sure this can be tested before the next release.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2074398763.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2074567310.zip)

<!-- download-section Build Python wheels end -->