### PR TITLE
add unit check and warning when saving

### DIFF
--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -483,6 +483,19 @@ class MetatensorAtomisticModel(torch.nn.Module):
         except RuntimeError as e:
             raise RuntimeError("could not convert the module to TorchScript") from e
 
+        if self._capabilities.length_unit == "":
+            warnings.warn(
+                "No `length_unit` was provided for the model.",
+                stacklevel=1,
+            )
+
+        for name, output in self._capabilities.outputs.items():
+            if output.unit == "":
+                warnings.warn(
+                    f"No units were provided for output {name!r}.",
+                    stacklevel=1,
+                )
+
         # TODO: can we freeze these?
         # module = torch.jit.freeze(module)
 

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -490,11 +490,14 @@ class MetatensorAtomisticModel(torch.nn.Module):
             )
 
         for name, output in self._capabilities.outputs.items():
-            if output.unit == "":
-                warnings.warn(
-                    f"No units were provided for output {name}.",
-                    stacklevel=1,
-                )
+            # TODO: coordinate a list of standard outputs needing
+            # unit checks, should also be consistent with `outputs.py`
+            if name in ["energy", "energy_ensemble"]:
+                if output.unit == "":
+                    warnings.warn(
+                        f"No units were provided for output {name}.",
+                        stacklevel=1,
+                    )
 
         # TODO: can we freeze these?
         # module = torch.jit.freeze(module)

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -485,14 +485,14 @@ class MetatensorAtomisticModel(torch.nn.Module):
 
         if self._capabilities.length_unit == "":
             warnings.warn(
-                "No `length_unit` was provided for the model.",
+                "No length unit was provided for the model.",
                 stacklevel=1,
             )
 
         for name, output in self._capabilities.outputs.items():
             if output.unit == "":
                 warnings.warn(
-                    f"No units were provided for output {name!r}.",
+                    f"No units were provided for output {name}.",
                     stacklevel=1,
                 )
 

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -304,5 +304,3 @@ def test_read_metadata(tmpdir):
     extracted_metadata = read_model_metadata(str(tmpdir / "model.pt"))
 
     assert str(extracted_metadata) == str(metadata)
-
-

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -60,7 +60,7 @@ def model():
         atomic_types=[1, 2, 3],
         interaction_range=4.3,
         outputs={
-            "energy": ModelOutput(
+            "tests::dummy::long": ModelOutput(
                 quantity="",
                 unit="",
                 per_atom=False,
@@ -73,6 +73,31 @@ def model():
 
     metadata = ModelMetadata()
     return MetatensorAtomisticModel(model, metadata, capabilities)
+
+
+@pytest.fixture
+def model_energy_nounit():
+    model_energy_nounit = MinimalModel()
+    model_energy_nounit.train(False)
+
+    capabilities = ModelCapabilities(
+        length_unit="angstrom",
+        atomic_types=[1, 2, 3],
+        interaction_range=4.3,
+        outputs={
+            "energy": ModelOutput(
+                quantity="",
+                unit="",
+                per_atom=False,
+                explicit_gradients=[],
+            ),
+        },
+        supported_devices=["cpu"],
+        dtype="float64",
+    )
+
+    metadata = ModelMetadata()
+    return MetatensorAtomisticModel(model_energy_nounit, metadata, capabilities)
 
 
 def test_save(model, tmp_path):
@@ -93,10 +118,10 @@ def test_save_warning_length_unit(model):
         model.save("export.pt")
 
 
-def test_save_warning_quantity(model):
+def test_save_warning_quantity(model_energy_nounit):
     match = r"No units were provided for output energy."
     with pytest.warns(UserWarning, match=match):
-        model.save("export.pt")
+        model_energy_nounit.save("export.pt")
 
 
 def test_export(model, tmp_path):

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -60,7 +60,7 @@ def model():
         atomic_types=[1, 2, 3],
         interaction_range=4.3,
         outputs={
-            "tests::dummy::long": ModelOutput(
+            "energy": ModelOutput(
                 quantity="",
                 unit="",
                 per_atom=False,
@@ -94,7 +94,7 @@ def test_save_warning_length_unit(model):
 
 
 def test_save_warning_quantity(model):
-    match = r"No units were provided for output tests::dummy::long."
+    match = r"No units were provided for output energy."
     with pytest.warns(UserWarning, match=match):
         model.save("export.pt")
 

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -86,6 +86,19 @@ def test_save(model, tmp_path):
     check_atomistic_model("export.pt")
 
 
+def test_save_warning_length_unit(model):
+    model._capabilities.length_unit = ""
+    match = r"No length unit was provided for the model."
+    with pytest.warns(UserWarning, match=match):
+        model.save("export.pt")
+
+
+def test_save_warning_quantity(model):
+    match = r"No units were provided for output tests::dummy::long."
+    with pytest.warns(UserWarning, match=match):
+        model.save("export.pt")
+
+
 def test_export(model, tmp_path):
     os.chdir(tmp_path)
     match = r"`export\(\)` is deprecated, use `save\(\)` instead"
@@ -291,3 +304,5 @@ def test_read_metadata(tmpdir):
     extracted_metadata = read_model_metadata(str(tmpdir / "model.pt"))
 
     assert str(extracted_metadata) == str(metadata)
+
+


### PR DESCRIPTION
This fixes #630.

Added simple checking routines within the save function to look for the units, and to raise a warning when the string is empty.
EDIT: took inspiration from the export function of metatrain as suggested by @Luthaf.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2098928048.zip)

<!-- download-section Documentation end -->