### PR TITLE
Allow TensorBlock components renaming

### DIFF
--- a/python/metatensor-operations/CHANGELOG.md
+++ b/python/metatensor-operations/CHANGELOG.md
@@ -6,16 +6,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatensor/)
 
-<!-- Possible sections
-
-### Added
-
-### Fixed
-
 ### Changed
-
-### Removed
--->
+- `axis="components"` can now be passed to `metatensor.operations.rename_dimension`.
 
 ## [Version 0.2.4](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.2.4) - 2024-10-11
 

--- a/python/metatensor-operations/CHANGELOG.md
+++ b/python/metatensor-operations/CHANGELOG.md
@@ -7,7 +7,7 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased](https://github.com/metatensor/metatensor/)
 
 ### Changed
-- `axis="components"` can now be passed to `metatensor.operations.rename_dimension`.
+- Issue #520, PR #763: `axis="components"` can now be passed to `metatensor.operations.rename_dimension`.
 
 ## [Version 0.2.4](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.2.4) - 2024-10-11
 

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -19,14 +19,14 @@ changing the columns of the :py:class:`metatensor.Labels` within).
 from typing import List, Union
 
 from . import _dispatch
-from ._backend import Array, TensorBlock, TensorMap, torch_jit_script
+from ._backend import Array, Labels, TensorBlock, TensorMap, torch_jit_script
 
 
 def _check_axis(axis: str):
-    if axis not in ["keys", "samples", "properties"]:
+    if axis not in ["keys", "samples", "properties", "components"]:
         raise ValueError(
-            f"'{axis}' is not a valid axis. Choose from 'keys', 'samples' or "
-            "'properties'."
+            f"'{axis}' is not a valid axis. Choose from 'keys', 'samples', "
+            "'properties', or 'components'."
         )
 
 
@@ -382,7 +382,7 @@ def rename_dimension(tensor: TensorMap, axis: str, old: str, new: str) -> Tensor
 
     :param tensor: the input :py:class:`TensorMap`.
     :param axis: axis for which the names should be appended. Allowed are ``"keys"``,
-                 ``"properties"`` or ``"samples"``.
+                 ``"properties"``, ``"samples"``, or ``"components"``.
     :param old: name to be replaced
     :param new: name after the replacement
 
@@ -418,30 +418,46 @@ def rename_dimension(tensor: TensorMap, axis: str, old: str, new: str) -> Tensor
     for block in tensor.blocks():
         samples = block.samples
         properties = block.properties
+        components = block.components
 
         if axis == "samples":
             samples = samples.rename(old, new)
         elif axis == "properties":
             properties = properties.rename(old, new)
+        elif axis == "components":
+            new_components: List[Labels] = []
+            for component in components:
+                if old in component.names:
+                    component = component.rename(old, new)
+                new_components.append(component)
+            components = new_components
 
         new_block = TensorBlock(
             values=block.values,
             samples=samples,
-            components=block.components,
+            components=components,
             properties=properties,
         )
 
         for parameter, gradient in block.gradients():
             gradient_samples = gradient.samples
+            gradient_components = gradient.components
             if axis == "samples" and old in gradient_samples.names:
                 gradient_samples = gradient_samples.rename(old, new)
+            elif axis == "components":
+                new_components: List[Labels] = []
+                for component in gradient_components:
+                    if old in component.names:
+                        component = component.rename(old, new)
+                    new_components.append(component)
+                gradient_components = new_components
 
             new_block.add_gradient(
                 parameter=parameter,
                 gradient=TensorBlock(
                     values=gradient.values,
                     samples=gradient_samples,
-                    components=gradient.components,
+                    components=gradient_components,
                     properties=properties,
                 ),
             )

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -23,7 +23,7 @@ from ._backend import Array, Labels, TensorBlock, TensorMap, torch_jit_script
 
 
 def _check_axis(axis: str):
-    if axis not in ["keys", "samples", "properties", "components"]:
+    if axis not in ["keys", "samples", "components", "properties"]:
         raise ValueError(
             f"'{axis}' is not a valid axis. Choose from 'keys', 'samples', "
             "'properties', or 'components'."

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -26,7 +26,7 @@ def _check_axis(axis: str):
     if axis not in ["keys", "samples", "components", "properties"]:
         raise ValueError(
             f"'{axis}' is not a valid axis. Choose from 'keys', 'samples', "
-            "'properties', or 'components'."
+            "'components', or 'properties'."
         )
 
 
@@ -382,7 +382,7 @@ def rename_dimension(tensor: TensorMap, axis: str, old: str, new: str) -> Tensor
 
     :param tensor: the input :py:class:`TensorMap`.
     :param axis: axis for which the names should be appended. Allowed are ``"keys"``,
-                 ``"properties"``, ``"samples"``, or ``"components"``.
+                 ``"samples"``, ``"components"``, or ``"properties"``.
     :param old: name to be replaced
     :param new: name after the replacement
 

--- a/python/metatensor-operations/tests/manipulate_dimension.py
+++ b/python/metatensor-operations/tests/manipulate_dimension.py
@@ -17,6 +17,11 @@ def tensor():
 
 
 @pytest.fixture
+def tensor_with_components_and_gradients():
+    return metatensor.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"))
+
+
+@pytest.fixture
 def tensor_extra():
     """TensorMap with gradient containing extra columns in keys, samples, properties"""
     block = TensorBlock(
@@ -236,6 +241,24 @@ def test_rename_properties(tensor):
     for block in new_tensor:
         for _, gradient in block.gradients():
             assert gradient.properties.names[0] == "foo"
+
+
+def test_rename_components(tensor_with_components_and_gradients):
+    new_tensor = metatensor.rename_dimension(
+        tensor_with_components_and_gradients,
+        axis="components",
+        old="o3_mu",
+        new="foo",
+    )
+    assert new_tensor.component_names[0] == "foo"
+
+    for block in new_tensor:
+        for parameter, gradient in block.gradients():
+            if parameter == "positions":
+                gradient_component_names = [["xyz"], ["foo"]]
+            elif parameter == "strain":
+                gradient_component_names = [["xyz_1"], ["xyz_2"], ["foo"]]
+            assert [c.names for c in gradient.components] == gradient_component_names
 
 
 def test_rename_unknown_axis(tensor):


### PR DESCRIPTION
Fixes #520. It allows passing `axis="components"` to `metatensor.operations.rename_dimension`.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2098956332.zip)

<!-- download-section Documentation end -->