### PR TITLE
Tox improvements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,16 @@ envlist =
 
 [testenv]
 passenv = *
+setenv =
+    # Do not use the user PYTHONPATH, tox is handling everything
+    PYTHONPATH=
+    # store code coverage in a per-env file, so different envs don't override each other
+    COVERAGE_FILE={env_dir}/.coverage
+
 package = external
 package_env = build-metatensor-core
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-
-setenv =
-    # store code coverage in a per-env file, so different envs don't override each other
-    COVERAGE_FILE={env_dir}/.coverage
 
 test_options =
     --cov={env_site_packages_dir}/metatensor \
@@ -48,6 +50,9 @@ testing_deps =
 # note: this is not redundant with the same value in the root [testenv] without this
 # one, cmake can not find the MSVC compiler on Windows CI
 passenv = *
+setenv =
+    # Do not use the user PYTHONPATH, tox is handling everything
+    PYTHONPATH=
 
 description =
     Used to only build the wheels which are then re-used by all other environments

--- a/tox.ini
+++ b/tox.ini
@@ -241,6 +241,9 @@ commands =
 
 [testenv:docs]
 description = build the documentation with sphinx
+setenv =
+    # build the docs against the CPU only version of torch
+    PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu {env:PIP_EXTRA_INDEX_URL:}
 deps =
     {[testenv]packaging_deps}
     cmake


### PR DESCRIPTION
- do not pass PYTHONPATH to tox
- set PIP_EXTRA_INDEX_URL to use CPU-only version of torch when building docs

Both issues found by @HannaTuerk, thanks!

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2099060993.zip)

<!-- download-section Documentation end -->