### PR TITLE
Added an option for strict neighbor list

### DIFF
--- a/metatensor-torch/src/register.cpp
+++ b/metatensor-torch/src/register.cpp
@@ -328,8 +328,8 @@ TORCH_LIBRARY(metatensor, m) {
     // ====================================================================== //
     m.class_<NeighborListOptionsHolder>("NeighborListOptions")
         .def(
-            torch::init<double, bool, std::string>(), DOCSTRING,
-            {torch::arg("cutoff"), torch::arg("full_list"), torch::arg("requestor") = ""}
+            torch::init<double, bool, bool, std::string>(), DOCSTRING,
+            {torch::arg("cutoff"), torch::arg("full_list"), torch::arg("strict"), torch::arg("requestor") = ""}
         )
         .def_property("cutoff", &NeighborListOptionsHolder::cutoff)
         .def_property("length_unit", &NeighborListOptionsHolder::length_unit, &NeighborListOptionsHolder::set_length_unit)
@@ -337,6 +337,7 @@ TORCH_LIBRARY(metatensor, m) {
             DOCSTRING, {torch::arg("engine_length_unit")}
         )
         .def_property("full_list", &NeighborListOptionsHolder::full_list)
+        .def_property("strict", &NeighborListOptionsHolder::strict)
         .def("requestors", &NeighborListOptionsHolder::requestors)
         .def("add_requestor", &NeighborListOptionsHolder::add_requestor, DOCSTRING,
             {torch::arg("requestor")}

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -10,12 +10,17 @@ using namespace Catch::Matchers;
 TEST_CASE("Models metadata") {
     SECTION("NeighborListOptions") {
         // save to JSON
-        auto options = torch::make_intrusive<NeighborListOptionsHolder>(3.5426, true);
+        auto options = torch::make_intrusive<NeighborListOptionsHolder>(
+            /*cutoff=*/ 3.5426,
+            /*full_list=*/ true,
+            /*strict=*/ true
+        );
         const auto* expected = R"({
     "class": "NeighborListOptions",
     "cutoff": 4615159644819978768,
     "full_list": true,
-    "length_unit": ""
+    "length_unit": "",
+    "strict": true
 })";
         CHECK(options->to_json() == expected);
 
@@ -23,11 +28,13 @@ TEST_CASE("Models metadata") {
         std::string json = R"({
     "cutoff": 4615159644819978768,
     "full_list": false,
+    "strict": false,
     "class": "NeighborListOptions"
 })";
         options = NeighborListOptionsHolder::from_json(json);
         CHECK(options->cutoff() == 3.5426);
         CHECK(options->full_list() == false);
+        CHECK(options->strict() == false);
 
         CHECK_THROWS_WITH(
             NeighborListOptionsHolder::from_json("{}"),

--- a/metatensor-torch/tests/neighbor-checks/README.md
+++ b/metatensor-torch/tests/neighbor-checks/README.md
@@ -14,3 +14,8 @@ For a half neighbor list, the pairs are also permitted to be in reverse order:
 When writing a new interface between metatensor and a simulation engine, you can
 use these files to ensure your neighbor list implementation follows the expected
 behavior for metatensor models.
+
+If your engine can produce non-`strict` neighbor lists, you can still use these
+files for testing. The pairs in the test files then correspond to the minimal
+set that must be included in the output, and any additional pair must be above
+the cutoff.

--- a/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/ase_calculator.py
@@ -486,6 +486,9 @@ def _ase_properties_to_metatensor_outputs(properties):
 
 
 def _compute_ase_neighbors(atoms, options, dtype, device):
+    # options.strict is ignored by this function, since `ase.neighborlist.neighbor_list`
+    # only computes strict NL, and these are valid even with `strict=False`
+
     if np.all(atoms.pbc) or np.all(~atoms.pbc):
         nl_i, nl_j, nl_S, nl_D = vesin.ase_neighbor_list(
             "ijSD",

--- a/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/documentation.py
@@ -166,11 +166,14 @@ class System:
 class NeighborListOptions:
     """Options for the calculation of a neighbors list"""
 
-    def __init__(self, cutoff: float, full_list: bool, requestor: str = ""):
+    def __init__(
+        self, cutoff: float, full_list: bool, strict: bool, requestor: str = ""
+    ):
         """
         :param cutoff: spherical cutoff radius for the neighbors list, in the
             model units
         :param full_list: should the list be a full or half neighbors list
+        :param strict: whether the list guarantee to have no pairs farther than cutoff
         :param requestor: who requested this neighbors list, you can add additional
             requestors later using :py:meth:`add_requestor`
         """
@@ -203,6 +206,13 @@ class NeighborListOptions:
         """
         Should the list be a full neighbors list (contains both the pair ``i->j`` and
         ``j->i``) or a half neighbors list (contains only the pair ``i->j``)
+        """
+
+    @property
+    def strict(self) -> bool:
+        """
+        Does the list guarantee to have no pairs beyond the cutoff (strict) or
+        can it also have pairs that are farther apart (non strict)
         """
 
     def requestors(self) -> List[str]:

--- a/python/metatensor-torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor-torch/tests/atomistic/ase_calculator.py
@@ -315,6 +315,8 @@ def _read_neighbor_check(path):
     options = NeighborListOptions(
         cutoff=data["options"]["cutoff"],
         full_list=data["options"]["full_list"],
+        # ASE can only compute strict NL
+        strict=True,
     )
 
     samples = torch.tensor(

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -45,9 +45,9 @@ class MinimalModel(torch.nn.Module):
 
     def requested_neighbor_lists(self) -> List[NeighborListOptions]:
         return [
-            NeighborListOptions(cutoff=1.2, full_list=False),
-            NeighborListOptions(cutoff=4.3, full_list=True),
-            NeighborListOptions(cutoff=1.2, full_list=False),
+            NeighborListOptions(cutoff=1.2, full_list=False, strict=True),
+            NeighborListOptions(cutoff=4.3, full_list=True, strict=True),
+            NeighborListOptions(cutoff=1.2, full_list=False, strict=False),
         ]
 
 
@@ -146,7 +146,7 @@ class ExampleModule(torch.nn.Module):
         return {}
 
     def requested_neighbor_lists(self) -> List[NeighborListOptions]:
-        return [NeighborListOptions(1.0, False, self._name)]
+        return [NeighborListOptions(1.0, False, True, self._name)]
 
 
 class OtherModule(torch.nn.Module):
@@ -162,7 +162,7 @@ class OtherModule(torch.nn.Module):
         return {}
 
     def requested_neighbor_lists(self) -> List[NeighborListOptions]:
-        return [NeighborListOptions(2.0, True, "other module")]
+        return [NeighborListOptions(2.0, True, False, "other module")]
 
 
 class FullModel(torch.nn.Module):
@@ -201,6 +201,7 @@ def test_requested_neighbor_lists():
 
     assert requests[0].cutoff == 1.0
     assert not requests[0].full_list
+    assert requests[0].strict
     assert requests[0].requestors() == [
         "first module",
         "FullModel.first",
@@ -210,6 +211,7 @@ def test_requested_neighbor_lists():
 
     assert requests[1].cutoff == 2.0
     assert requests[1].full_list
+    assert not requests[1].strict
     assert requests[1].requestors() == [
         "other module",
         "FullModel.other",

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -20,10 +20,11 @@ except ImportError:
 
 
 def test_neighbor_list_options():
-    options = NeighborListOptions(3.4, True, "hello")
+    options = NeighborListOptions(3.4, True, True, "hello")
 
     assert options.cutoff == 3.4
     assert options.full_list
+    assert options.strict
     assert options.requestors() == ["hello"]
 
     options.add_requestor("another one")
@@ -34,16 +35,22 @@ def test_neighbor_list_options():
     options.add_requestor("hello")
     assert options.requestors() == ["hello", "another one"]
 
-    assert NeighborListOptions(3.4, True, "a") == NeighborListOptions(3.4, True, "b")
-    assert NeighborListOptions(3.4, True) != NeighborListOptions(3.4, False)
-    assert NeighborListOptions(3.4, True) != NeighborListOptions(3.5, True)
+    assert NeighborListOptions(3.4, True, True, "a") == NeighborListOptions(
+        3.4, True, True, "b"
+    )
+    assert NeighborListOptions(3.4, True, True) != NeighborListOptions(3.4, False, True)
+    assert NeighborListOptions(3.4, False, True) != NeighborListOptions(
+        3.4, False, False
+    )
+    assert NeighborListOptions(3.4, True, True) != NeighborListOptions(3.5, True, True)
 
-    expected = "NeighborListOptions(cutoff=3.400000, full_list=True)"
+    expected = "NeighborListOptions(cutoff=3.400000, full_list=True, strict=True)"
     assert str(options) == expected
 
     expected = """NeighborListOptions
     cutoff: 3.400000
     full_list: True
+    strict: True
     requested by:
         - hello
         - another one
@@ -86,14 +93,14 @@ def test_neighbors_autograd():
 
         return neighbors.values.sum()
 
-    options = NeighborListOptions(cutoff=2.0, full_list=False)
+    options = NeighborListOptions(cutoff=2.0, full_list=False, strict=True)
     torch.autograd.gradcheck(
         compute,
         (positions, cell, options),
         fast_mode=True,
     )
 
-    options = NeighborListOptions(cutoff=2.0, full_list=True)
+    options = NeighborListOptions(cutoff=2.0, full_list=True, strict=True)
     torch.autograd.gradcheck(
         compute,
         (positions, cell, options),
@@ -116,7 +123,7 @@ def test_neighbor_autograd_errors():
         cell=cell.detach().numpy(),
         pbc=True,
     )
-    options = NeighborListOptions(cutoff=2.0, full_list=False)
+    options = NeighborListOptions(cutoff=2.0, full_list=False, strict=True)
     neighbors = _compute_ase_neighbors(
         atoms, options, dtype=torch.float64, device="cpu"
     )

--- a/python/metatensor-torch/tests/atomistic/systems.py
+++ b/python/metatensor-torch/tests/atomistic/systems.py
@@ -84,28 +84,30 @@ def test_system(types, positions, cell, pbc, neighbors):
         # custom __repr__ definitions are only available since torch 2.1
         assert repr(system) == expected
 
-    options = NeighborListOptions(cutoff=3.5, full_list=False)
+    options = NeighborListOptions(cutoff=3.5, full_list=False, strict=True)
     system.add_neighbor_list(options, neighbors)
 
     assert metatensor.torch.equal_block(system.get_neighbor_list(options), neighbors)
 
     message = (
         "No neighbor list for NeighborListOptions\\(cutoff=3.500000, "
-        "full_list=True\\) was found.\n"
+        "full_list=True, strict=True\\) was found.\n"
         "Is it part of the `requested_neighbor_lists` for this model?"
     )
     with pytest.raises(ValueError, match=message):
-        system.get_neighbor_list(NeighborListOptions(cutoff=3.5, full_list=True))
+        system.get_neighbor_list(
+            NeighborListOptions(cutoff=3.5, full_list=True, strict=True)
+        )
 
     message = (
         "the neighbors list for NeighborListOptions\\(cutoff=3.500000, "
-        "full_list=False\\) already exists in this system"
+        "full_list=False, strict=True\\) already exists in this system"
     )
     with pytest.raises(ValueError, match=message):
         system.add_neighbor_list(options, neighbors)
 
     assert system.known_neighbor_lists() == [
-        NeighborListOptions(cutoff=3.5, full_list=False)
+        NeighborListOptions(cutoff=3.5, full_list=False, strict=True)
     ]
 
 
@@ -318,7 +320,7 @@ def test_data_validation(types, positions, cell, pbc):
 
 
 def test_neighbors_validation(system):
-    options = NeighborListOptions(cutoff=3.5, full_list=False)
+    options = NeighborListOptions(cutoff=3.5, full_list=False, strict=True)
 
     message = (
         "invalid samples for `neighbors`: the samples names must be 'first_atom', "
@@ -465,7 +467,7 @@ def test_neighbors_validation(system):
 
 
 def test_to(system, neighbors):
-    options = NeighborListOptions(cutoff=3.5, full_list=False)
+    options = NeighborListOptions(cutoff=3.5, full_list=False, strict=True)
     system.add_neighbor_list(options, neighbors)
     system.add_data("test-data", neighbors)
 

--- a/tox.ini
+++ b/tox.ini
@@ -177,7 +177,7 @@ commands =
     pip install ../metatensor-learn {[testenv]build_single_wheel} --force-reinstall
 
     # use the reference LJ implementation for tests
-    pip install {[testenv]build_single_wheel} git+https://github.com/Luthaf/metatensor-lj-test@caeb6a6
+    pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@cb22e94
 
     # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py


### PR DESCRIPTION
Adds a flag to the neighbor list classes to signal whether the neighbor list is "strict" - that is if it guarantees not to pass atoms beyond the cutoff. 


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2116989539.zip)

<!-- download-section Documentation end -->