### PR TITLE
split blocks (and maps) by index as well as by label

### DIFF
--- a/python/metatensor-learn/tests/_tests_utils.py
+++ b/python/metatensor-learn/tests/_tests_utils.py
@@ -124,17 +124,23 @@ def generate_data(sample_indices):
         input_A = metatensor.slice(
             input,
             "samples",
-            labels=Labels(names=["sample_index"], values=np.array([A]).reshape(-1, 1)),
+            selection=Labels(
+                names=["sample_index"], values=np.array([A]).reshape(-1, 1)
+            ),
         )
         output_A = metatensor.slice(
             output,
             "samples",
-            labels=Labels(names=["sample_index"], values=np.array([A]).reshape(-1, 1)),
+            selection=Labels(
+                names=["sample_index"], values=np.array([A]).reshape(-1, 1)
+            ),
         )
         auxiliary_A = metatensor.slice(
             auxiliary,
             "samples",
-            labels=Labels(names=["sample_index"], values=np.array([A]).reshape(-1, 1)),
+            selection=Labels(
+                names=["sample_index"], values=np.array([A]).reshape(-1, 1)
+            ),
         )
         # Store in memory
         inputs.append(input_A)

--- a/python/metatensor-operations/CHANGELOG.md
+++ b/python/metatensor-operations/CHANGELOG.md
@@ -17,6 +17,13 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Changed
+
+- `split`, `split_block`, `slice` and `slice_block` have been updated to accept
+  a list of integer directly specifying which samples/properties to keep in the
+  output. The corresponding parameter has been renamed to `selection` or
+  `selections` (for `slice` and `split` respectively) (#772)
+
 ## [Version 0.2.4](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.2.4) - 2024-10-11
 
 ### Changed

--- a/python/metatensor-operations/metatensor/operations/_backend.py
+++ b/python/metatensor-operations/metatensor/operations/_backend.py
@@ -27,6 +27,9 @@ Labels = metatensor.Labels
 TensorBlock = metatensor.TensorBlock
 TensorMap = metatensor.TensorMap
 
+# type used by the values in Labels
+LabelsValues = np.ndarray
+
 
 def torch_jit_is_scripting():
     return False

--- a/python/metatensor-operations/metatensor/operations/split.py
+++ b/python/metatensor-operations/metatensor/operations/split.py
@@ -1,37 +1,38 @@
 from typing import Dict, List
 
 from ._backend import (
-    Labels,
     TensorBlock,
     TensorMap,
     check_isinstance,
     torch_jit_is_scripting,
     torch_jit_script,
 )
-from .slice import _slice_block
+from .slice import SliceSelection, _check_slice_args, _slice_block
 
 
 def _split_block(
     block: TensorBlock,
     axis: str,
-    grouped_labels: List[Labels],
+    selections: List[SliceSelection],
 ) -> List[TensorBlock]:
     """
     Splits a TensorBlock into multiple blocks, as in the public function
-    :py:func:`split_block` but with no input checks. Note that the block is currently
-    split into N new blocks by performing N number of slice operations. There may be a
-    more efficient way of doing it, but this is not yet implemented.
+    :py:func:`split_block` but with no input checks.
+
+    Note that the block is currently split into N new blocks by performing N number of
+    slice operations. There may be a more efficient way of doing it, but this is not yet
+    implemented.
     """
     new_blocks: List[TensorBlock] = []
-    for indices in grouped_labels:
+    for selection in selections:
         # perform the slice either along the samples or properties axis
-        new_block = _slice_block(block, axis=axis, labels=indices)
+        new_block = _slice_block(block, axis=axis, selection=selection)
         new_blocks.append(new_block)
 
     return new_blocks
 
 
-def _check_args(block: TensorBlock, axis: str, grouped_labels: List[Labels]):
+def _check_split_args(block: TensorBlock, axis: str, selections: List[SliceSelection]):
     """
     Checks the arguments passed to :py:func:`split` and :py:func:`split_block`.
     """
@@ -40,57 +41,33 @@ def _check_args(block: TensorBlock, axis: str, grouped_labels: List[Labels]):
         if not isinstance(axis, str):
             raise TypeError(f"axis must be a string, not {type(axis)}")
 
-        if not isinstance(grouped_labels, list):
-            raise TypeError(
-                f"`grouped_labels` must be a list, not {type(grouped_labels)}"
-            )
-
-        for labels in grouped_labels:
-            if not check_isinstance(labels, Labels):
-                raise TypeError(
-                    "`grouped_labels` elements must be metatensor Labels, "
-                    f"not {type(labels)}"
-                )
+        if not isinstance(selections, list):
+            raise TypeError(f"`selections` must be a list, not {type(selections)}")
 
     if axis not in ["samples", "properties"]:
         raise ValueError("axis must be either 'samples' or 'properties'")
 
     # If passed as an empty list, return now
-    if len(grouped_labels) == 0:
+    if len(selections) == 0:
         return
 
-    # Check the Labels names are equivalent for all Labels in grouped_labels
-    reference_names = grouped_labels[0].names
-    for labels in grouped_labels[1:]:
-        if labels.names != reference_names:
-            raise ValueError(
-                "the dimensions names of all Labels in `grouped_labels`"
-                f" must be the same, got {reference_names} and {labels.names}"
-            )
-
-    # Check the names in grouped_labels Labels are contained within the names for
-    # the block
-    names = block.samples.names if axis == "samples" else block.properties.names
-    for name in reference_names:
-        if name not in names:
-            raise ValueError(
-                f"the '{name}' dimension name in `grouped_labels` is not part of "
-                f"the {axis} names of the input tensor"
-            )
+    # Delegate to slice the checking of the selections
+    for selection in selections:
+        _check_slice_args(block, axis, selection)
 
 
 @torch_jit_script
 def split(
     tensor: TensorMap,
     axis: str,
-    grouped_labels: List[Labels],
+    selections: List[SliceSelection],
 ) -> List[TensorMap]:
     """
     Split a :py:class:`TensorMap` into multiple :py:class:`TensorMap`.
 
     The operation is based on some specified groups of indices, along either the
     "samples" or "properties" ``axis``. The length of the returned list is equal to the
-    number of :py:class:`Labels` objects passed in ``grouped_labels``. Each returned
+    number of :py:class:`Labels` objects passed in ``selections``. Each returned
     :py:class`TensorMap` will have the same keys and number of blocks at the input
     ``tensor``, but with the dimensions of the blocks reduced to only contain the
     specified indices for the corresponding group.
@@ -117,7 +94,7 @@ def split(
     >>> splitted = metatensor.split(
     ...     tensor,
     ...     axis="samples",
-    ...     grouped_labels=[
+    ...     selections=[
     ...         Labels(names=["system"], values=np.array([[0], [6], [7]])),
     ...         Labels(names=["system"], values=np.array([[2], [3], [4]])),
     ...         Labels(names=["system"], values=np.array([[1], [5], [8], [10]])),
@@ -151,16 +128,19 @@ def split(
     :param tensor: a :py:class:`TensorMap` to be split
     :param axis: a str, either "samples" or "properties", that indicates the
         :py:class:`TensorBlock` axis along which the named index (or indices) in
-        ``grouped_labels`` belongs. Each :py:class:`TensorBlock` in each returned
+        ``selections`` belongs. Each :py:class:`TensorBlock` in each returned
         :py:class:`TensorMap` could have a reduced dimension along this axis, but the
         other axes will remain the same size.
-    :param grouped_labels: a list of :py:class:`Labels` containing the names and values
-        of the indices along the specified ``axis`` which should be in each respective
-        output :py:class:`TensorMap`.
+    :param selections: a list of selections specifying what should be included in the
+        different outputs. Each entry in the list can either be a :py:class:`Labels`
+        selection, an array or a ``List[int]`` indicating the raw indices that should be
+        kept. The list can mix different types of selections. When using
+        :py:class:`Labels` selection, only a subset of the corresponding dimension names
+        can be specified, and any entry with matching values will be selected.
 
     :return: a list of:py:class:`TensorMap` that corresponds to the split input
         ``tensor``. Each tensor in the returned list contains only the named indices in
-        the respective py:class:`Labels` object of ``grouped_labels``.
+        the respective py:class:`Labels` object of ``selections``.
     """
     # Check input args
     if not torch_jit_is_scripting():
@@ -169,23 +149,23 @@ def split(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
 
-    _check_args(tensor.block(0), axis, grouped_labels)
+    _check_split_args(tensor.block(0), axis, selections)
 
     all_new_blocks: Dict[int, List[TensorBlock]] = {}
-    for group_i in range(len(grouped_labels)):
+    for group_i in range(len(selections)):
         empty_list: List[TensorBlock] = []
         all_new_blocks[group_i] = empty_list
 
     for key_index in range(len(tensor.keys)):
         key = tensor.keys.entry(key_index)
-        new_blocks = _split_block(tensor[key], axis, grouped_labels)
+        new_blocks = _split_block(tensor[key], axis, selections)
 
         for group_i, new_block in enumerate(new_blocks):
             all_new_blocks[group_i].append(new_block)
 
     return [
         TensorMap(keys=tensor.keys, blocks=all_new_blocks[group_i])
-        for group_i in range(len(grouped_labels))
+        for group_i in range(len(selections))
     ]
 
 
@@ -193,16 +173,16 @@ def split(
 def split_block(
     block: TensorBlock,
     axis: str,
-    grouped_labels: List[Labels],
+    selections: List[SliceSelection],
 ) -> List[TensorBlock]:
     """
     Splits an input :py:class:`TensorBlock` into multiple :py:class:`TensorBlock`
-    objects based on some specified ``grouped_labels``, along either the ``"samples"``
-    or ``"properties"`` ``axis``. The length of the returned list is equal to the number
-    of :py:class:`Labels` objects passed in ``grouped_labels``. Each returned
-    :py:class`TensorBlock` will have the same keys and number of blocks at the input
-    ``tensor``, but with the dimensions of the blocks reduced to only contain the
-    specified indices for the corresponding group.
+    objects based on some specified ``selections``, along either the ``"samples"`` or
+    ``"properties"`` ``axis``. The length of the returned list is equal to the number of
+    selections passed in ``selections``. Each returned :py:class`TensorBlock` will have
+    the same keys and number of blocks at the input ``tensor``, but with the dimensions
+    of the blocks reduced to only contain the specified indices for the corresponding
+    group.
 
     For example, to split a block along the ``"samples"`` axis, according to the
     ``"system"`` index, where system 0, 6, and 7 are in the first returned
@@ -224,7 +204,7 @@ def split_block(
     >>> splitted = metatensor.split_block(
     ...     block,
     ...     axis="samples",
-    ...     grouped_labels=[
+    ...     selections=[
     ...         Labels(names=["system"], values=np.array([[0], [6], [7]])),
     ...         Labels(names=["system"], values=np.array([[2], [3], [4]])),
     ...         Labels(names=["system"], values=np.array([[1], [5], [8], [10]])),
@@ -258,15 +238,18 @@ def split_block(
     :param block: a :py:class:`TensorBlock` to be split
     :param axis: a str, either "samples" or "properties", that indicates the
         :py:class:`TensorBlock` axis along which the named index (or indices) in
-        ``grouped_labels`` belongs. Each :py:class:`TensorBlock` returned could have a
+        ``selections`` belongs. Each :py:class:`TensorBlock` returned could have a
         reduced dimension along this axis, but the other axes will remain the same size.
-    :param grouped_labels: a list of :py:class:`Labels` containing the names and values
-        of the indices along the specified ``axis`` which should be in each respective
-        output :py:class:`TensorBlock`.
+    :param selections: a list of selections specifying what should be included in the
+        different outputs. Each entry in the list can either be a :py:class:`Labels`
+        selection, an array or a ``List[int]`` indicating the raw indices that should be
+        kept. The list can mix different types of selections. When using
+        :py:class:`Labels` selection, only a subset of the corresponding dimension names
+        can be specified, and any entry with matching values will be selected.
 
     :return: a list of:py:class:`TensorBlock` that corresponds to the split input
         ``block``. Each block in the returned list contains only the named indices in
-        the respective py:class:`Labels` object of ``grouped_labels``.
+        the respective py:class:`Labels` object of ``selections``.
     """
     # Check input args
     if not torch_jit_is_scripting():
@@ -275,6 +258,6 @@ def split_block(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )
 
-    _check_args(block, axis, grouped_labels)
+    _check_split_args(block, axis, selections)
 
-    return _split_block(block, axis, grouped_labels)
+    return _split_block(block, axis, selections)

--- a/python/metatensor-operations/tests/join.py
+++ b/python/metatensor-operations/tests/join.py
@@ -102,13 +102,13 @@ def test_join_properties_values(tensor):
         tensor[0].properties.names,
         tensor[0].properties.values[:1],
     )
-    slice_1 = metatensor.slice(tensor, axis="properties", labels=first_property)
+    slice_1 = metatensor.slice(tensor, axis="properties", selection=first_property)
 
     other_properties = Labels(
         tensor[0].properties.names,
         tensor[0].properties.values[1:],
     )
-    slice_2 = metatensor.slice(tensor, axis="properties", labels=other_properties)
+    slice_2 = metatensor.slice(tensor, axis="properties", selection=other_properties)
 
     joined_tensor = metatensor.join([slice_1, slice_2], axis="properties")
 
@@ -204,13 +204,13 @@ def test_join_samples_values(tensor):
         tensor[0].samples.names,
         tensor[0].samples.values[:1],
     )
-    slice_1 = metatensor.slice(tensor, axis="samples", labels=first_samples)
+    slice_1 = metatensor.slice(tensor, axis="samples", selection=first_samples)
 
     other_samples = Labels(
         tensor[0].samples.names,
         tensor[0].samples.values[1:],
     )
-    slice_2 = metatensor.slice(tensor, axis="samples", labels=other_samples)
+    slice_2 = metatensor.slice(tensor, axis="samples", selection=other_samples)
 
     joined_tensor = metatensor.join([slice_1, slice_2], axis="samples")
 
@@ -267,7 +267,7 @@ def test_split_join_samples(tensor):
     labels_2 = Labels(names=["system"], values=np.arange(4, 10).reshape(-1, 1))
 
     split_tensors = metatensor.split(
-        tensor=tensor, axis="samples", grouped_labels=[labels_1, labels_2]
+        tensor=tensor, axis="samples", selections=[labels_1, labels_2]
     )
     joined_tensor = metatensor.join(
         split_tensors, axis="samples", remove_tensor_name=True
@@ -284,7 +284,7 @@ def test_split_join_properties(tensor):
     labels_2 = Labels(names=properties.names, values=properties.values[5:])
 
     split_tensors = metatensor.split(
-        tensor=tensor, axis="properties", grouped_labels=[labels_1, labels_2]
+        tensor=tensor, axis="properties", selections=[labels_1, labels_2]
     )
     joined_tensor = metatensor.join(
         split_tensors, axis="properties", remove_tensor_name=True

--- a/python/metatensor-operations/tests/split.py
+++ b/python/metatensor-operations/tests/split.py
@@ -15,20 +15,18 @@ def test_split_block_samples():
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"))
     block = tensor.block(o3_lambda=2, center_type=6, neighbor_type=6)
 
-    grouped_labels = [
+    selections = [
         Labels(names=["system"], values=np.array([[0], [6], [7]])),
         Labels(names=["system"], values=np.array([[2], [3], [4]])),
         Labels(names=["system"], values=np.array([[1], [5], [8], [9]])),
     ]
 
-    splitted = metatensor.split_block(
-        block, axis="samples", grouped_labels=grouped_labels
-    )
+    splitted = metatensor.split_block(block, axis="samples", selections=selections)
 
     assert len(splitted) == 3
     assert sum(len(b.samples) for b in splitted) == len(block.samples)
 
-    for split_block, expected_samples in zip(splitted, grouped_labels):
+    for split_block, expected_samples in zip(splitted, selections):
         structure_values = np.unique(split_block.samples["system"]).reshape(-1, 1)
         assert np.all(structure_values == expected_samples.values)
 
@@ -65,17 +63,15 @@ def test_split_block_samples_not_everything():
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"))
     block = tensor.block(o3_lambda=2, center_type=6, neighbor_type=6)
 
-    # using `grouped_labels` with some samples not present in the initial block,
+    # using `selections` with some samples not present in the initial block,
     # and not including all samples
-    grouped_labels = [
+    selections = [
         # 1 is in the samples, 12 is not
         Labels(names=["system"], values=np.array([[1], [12]])),
         # 18 is not in the samples
         Labels(names=["system"], values=np.array([[18]])),
     ]
-    splitted = metatensor.split_block(
-        block, axis="samples", grouped_labels=grouped_labels
-    )
+    splitted = metatensor.split_block(block, axis="samples", selections=selections)
 
     assert len(splitted) == 2
     partial = splitted[0]
@@ -88,25 +84,25 @@ def test_split_block_samples_not_everything():
     assert empty.components == block.components
     assert empty.properties == block.properties
 
-    # an empty list of grouped_labels gets you an empty list of blocks
-    assert metatensor.split_block(block, axis="samples", grouped_labels=[]) == []
+    # an empty list of selections gets you an empty list of blocks
+    assert metatensor.split_block(block, axis="samples", selections=[]) == []
 
 
 def test_split_samples():
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"))
 
-    grouped_labels = [
+    selections = [
         Labels(names=["system"], values=np.array([[0], [6], [7]])),
         Labels(names=["system"], values=np.array([[2], [3], [4]])),
         Labels(names=["system"], values=np.array([[1], [5], [8], [9]])),
     ]
 
-    splitted = metatensor.split(tensor, axis="samples", grouped_labels=grouped_labels)
+    splitted = metatensor.split(tensor, axis="samples", selections=selections)
 
     for split_tensor in splitted:
         assert split_tensor.keys == tensor.keys
 
-    for split_tensor, expected_samples in zip(splitted, grouped_labels):
+    for split_tensor, expected_samples in zip(splitted, selections):
         for split_block, block in zip(split_tensor, tensor):
             split_structures = Labels(
                 ["system"],
@@ -122,8 +118,8 @@ def test_split_samples():
             assert split_block.components == block.components
             assert split_block.properties == block.properties
 
-    # an empty list of grouped_labels gets you an empty list of tensors
-    assert metatensor.split(tensor, axis="samples", grouped_labels=[]) == []
+    # an empty list of selections gets you an empty list of tensors
+    assert metatensor.split(tensor, axis="samples", selections=[]) == []
 
 
 def test_split_block_properties():
@@ -131,17 +127,15 @@ def test_split_block_properties():
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"))
     block = tensor.block(center_type=8, neighbor_1_type=6, neighbor_2_type=8)
 
-    grouped_labels = [
+    selections = [
         Labels(names=["l", "n_2"], values=np.array([[0, 0], [1, 3], [3, 1]])),
         Labels(names=["l", "n_2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
         Labels(names=["l", "n_2"], values=np.array([[3, 2], [1, 1]])),
     ]
-    splitted = metatensor.split_block(
-        block, axis="properties", grouped_labels=grouped_labels
-    )
+    splitted = metatensor.split_block(block, axis="properties", selections=selections)
 
     assert len(splitted) == 3
-    for split_block, expected_properties in zip(splitted, grouped_labels):
+    for split_block, expected_properties in zip(splitted, selections):
         # no changes to samples & components
         assert split_block.samples == block.samples
         assert split_block.components == block.components
@@ -166,27 +160,25 @@ def test_split_block_properties():
 
             assert np.all(split_gradient.values == gradient.values[..., mask])
 
-    # an empty list of grouped_labels gets you an empty list of blocks
-    assert metatensor.split_block(block, axis="properties", grouped_labels=[]) == []
+    # an empty list of selections gets you an empty list of blocks
+    assert metatensor.split_block(block, axis="properties", selections=[]) == []
 
 
 def test_split_properties():
     # TensorMap with multiple properties
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"))
 
-    grouped_labels = [
+    selections = [
         Labels(names=["l", "n_2"], values=np.array([[0, 0], [1, 3], [3, 1]])),
         Labels(names=["l", "n_2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
         Labels(names=["l", "n_2"], values=np.array([[3, 2], [1, 1]])),
     ]
-    splitted = metatensor.split(
-        tensor, axis="properties", grouped_labels=grouped_labels
-    )
+    splitted = metatensor.split(tensor, axis="properties", selections=selections)
 
     for split_tensor in splitted:
         assert split_tensor.keys == tensor.keys
 
-    for split_tensor, expected_properties in zip(splitted, grouped_labels):
+    for split_tensor, expected_properties in zip(splitted, selections):
         for split_block, block in zip(split_tensor, tensor):
             # no changes to samples & components
             assert split_block.samples == block.samples
@@ -195,14 +187,14 @@ def test_split_properties():
             for p in split_block.properties.view(expected_properties.names):
                 assert p in expected_properties
 
-    # an empty list of grouped_labels gets you an empty list of blocks
-    assert metatensor.split(tensor, axis="properties", grouped_labels=[]) == []
+    # an empty list of selections gets you an empty list of blocks
+    assert metatensor.split(tensor, axis="properties", selections=[]) == []
 
 
 def test_split_errors():
     tensor = metatensor.load(os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"))
     block = tensor.block(4)
-    grouped_labels = [
+    selections = [
         Labels(names=["system"], values=np.array([[0], [6], [7]])),
         Labels(names=["system"], values=np.array([[2], [3], [4]])),
         Labels(names=["system"], values=np.array([[1], [5], [8], [9]])),
@@ -213,40 +205,38 @@ def test_split_errors():
         "not <class 'metatensor.block.TensorBlock'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.split(block, axis="samples", grouped_labels=grouped_labels)
+        metatensor.split(block, axis="samples", selections=selections)
 
     message = "axis must be a string, not <class 'float'>"
     with pytest.raises(TypeError, match=message):
-        metatensor.split(tensor, axis=3.14, grouped_labels=grouped_labels)
+        metatensor.split(tensor, axis=3.14, selections=selections)
 
     message = "axis must be either 'samples' or 'properties'"
     with pytest.raises(ValueError, match=message):
-        metatensor.split(tensor, axis="buongiorno!", grouped_labels=grouped_labels)
+        metatensor.split(tensor, axis="buongiorno!", selections=selections)
+
+    message = "`selections` must be a list, " "not <class 'metatensor.labels.Labels'>"
+    with pytest.raises(TypeError, match=message):
+        metatensor.split(tensor, axis="samples", selections=selections[0])
 
     message = (
-        "`grouped_labels` must be a list, " "not <class 'metatensor.labels.Labels'>"
+        "`selection` must be metatensor Labels, an array or List\\[int\\], "
+        "not <class 'str'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.split(tensor, axis="samples", grouped_labels=grouped_labels[0])
+        metatensor.split(tensor, axis="samples", selections=["a", "b", "c"])
 
-    message = "`grouped_labels` elements must be metatensor Labels, not <class 'str'>"
-    with pytest.raises(TypeError, match=message):
-        metatensor.split(tensor, axis="samples", grouped_labels=["a", "b", "c"])
-
-    grouped_labels = [
+    selections = [
         Labels(names=["red"], values=np.array([[0], [6], [7]])),
         Labels(names=["red"], values=np.array([[2], [3], [4]])),
         Labels(names=["wine"], values=np.array([[1], [5], [8], [9]])),
     ]
 
-    message = (
-        "the dimensions names of all Labels in `grouped_labels` must be the same, "
-        "got \\['red'\\] and \\['wine'\\]"
-    )
+    message = "invalid sample name 'red' which is not part of the input"
     with pytest.raises(ValueError, match=message):
-        metatensor.split(tensor, axis="samples", grouped_labels=grouped_labels)
+        metatensor.split(tensor, axis="samples", selections=selections)
 
-    grouped_labels = [
+    selections = [
         Labels(names=["missing", "atom"], values=np.array([[0, 1], [6, 7], [7, 4]])),
         Labels(names=["missing", "atom"], values=np.array([[2, 4], [3, 3], [4, 7]])),
         Labels(
@@ -255,16 +245,13 @@ def test_split_errors():
         ),
     ]
 
-    message = (
-        "the 'missing' dimension name in `grouped_labels` is not part of "
-        "the samples names of the input tensor"
-    )
+    message = "invalid sample name 'missing' which is not part of the input"
     with pytest.raises(ValueError, match=message):
-        metatensor.split(tensor, axis="samples", grouped_labels=grouped_labels)
+        metatensor.split(tensor, axis="samples", selections=selections)
 
     message = (
         "`block` must be a metatensor TensorBlock, "
         "not <class 'metatensor.tensor.TensorMap'>"
     )
     with pytest.raises(TypeError, match=message):
-        metatensor.split_block(tensor, axis="samples", grouped_labels=[])
+        metatensor.split_block(tensor, axis="samples", selections=[])

--- a/python/metatensor-operations/tests/unique_metadata.py
+++ b/python/metatensor-operations/tests/unique_metadata.py
@@ -75,7 +75,7 @@ def test_empty_block(real_tensor):
     sliced_block = metatensor.slice_block(
         real_tensor.block(0),
         axis="samples",
-        labels=Labels(names=["system"], values=np.array([[-1]])),
+        selection=Labels(names=["system"], values=np.array([[-1]])),
     )
     actual_samples = metatensor.unique_metadata_block(
         sliced_block,
@@ -89,7 +89,7 @@ def test_empty_block(real_tensor):
     sliced_block = metatensor.slice_block(
         real_tensor.block(0),
         axis="properties",
-        labels=Labels(names=["n"], values=np.array([[-1]])),
+        selection=Labels(names=["n"], values=np.array([[-1]])),
     )
     actual_properties = metatensor.unique_metadata_block(
         sliced_block,

--- a/python/metatensor-torch/metatensor/torch/operations.py
+++ b/python/metatensor-torch/metatensor/torch/operations.py
@@ -55,6 +55,7 @@ module.__dict__["Labels"] = Labels
 module.__dict__["TensorBlock"] = TensorBlock
 module.__dict__["TensorMap"] = TensorMap
 module.__dict__["Array"] = torch.Tensor
+module.__dict__["LabelsValues"] = torch.Tensor
 
 if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX", "0") != "0":
     # disable TorchScript compilation when importing the code with

--- a/python/metatensor-torch/tests/operations/slice.py
+++ b/python/metatensor-torch/tests/operations/slice.py
@@ -17,10 +17,10 @@ def test_slice():
     samples = Labels(names=["sample"], values=torch.tensor([[1]]))
     properties = Labels(names=["property"], values=torch.tensor([[1]]))
     sliced_tensor_samples = metatensor.torch.slice(
-        tensor, axis="samples", labels=samples
+        tensor, axis="samples", selection=samples
     )
     sliced_tensor_properties = metatensor.torch.slice(
-        tensor, axis="properties", labels=properties
+        tensor, axis="properties", selection=properties
     )
 
     # check type
@@ -43,10 +43,10 @@ def test_slice_block():
     samples = Labels(names=["sample"], values=torch.tensor([[1]]))
     properties = Labels(names=["property"], values=torch.tensor([[1]]))
     sliced_block_samples = metatensor.torch.slice_block(
-        block, axis="samples", labels=samples
+        block, axis="samples", selection=samples
     )
     sliced_block_properties = metatensor.torch.slice_block(
-        block, axis="properties", labels=properties
+        block, axis="properties", selection=properties
     )
 
     # check type


### PR DESCRIPTION
Fixes #187. One pain point for me in using mts is when I know that I want to pick a slice of a block, I know what indices I need, and instead I've to figure out how to do the same thing by sample labels. This PR (that looks like could be pretty simple) implement direct selection by indices.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2112623199.zip)

<!-- download-section Documentation end -->