### PR TITLE
Make `vesin` a dependency of `metatensor-torch`

### DIFF
--- a/python/metatensor-torch/setup.py
+++ b/python/metatensor-torch/setup.py
@@ -308,7 +308,7 @@ if __name__ == "__main__":
         # otherwise we are building a sdist
         torch_version = ">= 1.12"
 
-    install_requires = [f"torch {torch_version}"]
+    install_requires = [f"torch {torch_version}", "vesin"]
 
     # when packaging a sdist for release, we should never use local dependencies
     METATENSOR_NO_LOCAL_DEPS = os.environ.get("METATENSOR_NO_LOCAL_DEPS", "0") == "1"

--- a/python/metatensor-torch/tests/atomistic/neighbors.py
+++ b/python/metatensor-torch/tests/atomistic/neighbors.py
@@ -137,7 +137,7 @@ def test_neighbor_autograd_errors():
 
     message = (
         r"one neighbor pair does not match its metadata: the pair between atom \d+ and "
-        r"atom \d+ for the \[\d+, \d+, \d+\] cell shift should have a distance vector "
+        r"atom \d+ for the \[.*?\] cell shift should have a distance vector "
         r"of \[.*?\] but has a distance vector of \[.*?\]"
     )
     neighbors = _compute_ase_neighbors(

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ testing_deps =
     pytest
     pytest-cov
     toml
+    vesin
 
 
 [testenv:build-metatensor-core]
@@ -246,7 +247,7 @@ setenv =
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu {env:PIP_EXTRA_INDEX_URL:}
 deps =
     {[testenv]packaging_deps}
-    cmake
+    {[testenv]testing_deps}
 
     sphinx == 7.4.*
     sphinx-toggleprompt # hide the prompt (>>>) in python doctests


### PR DESCRIPTION
Makes `vesin` a dependency to make sure it is used when running MD with ASE or i-PI.
This can provide a huge speed boost (up to 15x) for fast models.


# Contributor (creator of pull-request) checklist

 ~~- [ ] Tests updated (for new features and bugfixes)?~~
 - [x] Documentation updated (for new features)?
 ~~- [ ] Issue referenced (for PRs that solve an issue)?~~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2113196843.zip)

<!-- download-section Build Python wheels end -->

<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2113010210.zip)

<!-- download-section Documentation end -->