### PR TITLE
Warn when using types from `-torch` with operations from `-core`

### DIFF
--- a/python/metatensor-core/tests/data.py
+++ b/python/metatensor-core/tests/data.py
@@ -114,7 +114,7 @@ class ArrayWrapperMixin:
         array_copy = metatensor.data.mts_array_to_python_array(copy)
         assert id(array_copy) != id(array)
 
-        assert_equal(np.array(array_copy), np.array(array))
+        assert_equal(self.to_numpy(array_copy), self.to_numpy(array))
 
         free_mts_array(mts_array)
         free_mts_array(copy)
@@ -170,6 +170,9 @@ class TestNumpyData(ArrayWrapperMixin):
     def create_array(self, shape):
         return np.zeros(shape)
 
+    def to_numpy(self, array):
+        return np.array(array)
+
 
 if HAS_TORCH:
 
@@ -179,6 +182,9 @@ if HAS_TORCH:
 
         def create_array(self, shape):
             return torch.zeros(shape, device="cpu")
+
+        def to_numpy(self, array):
+            return array.numpy()
 
 
 def _get_shape(mts_array, test):

--- a/python/metatensor-learn/metatensor/learn/_backend.py
+++ b/python/metatensor-learn/metatensor/learn/_backend.py
@@ -9,20 +9,60 @@
 #
 # Any change to this file MUST be also be made to `metatensor/torch/learn.py`.
 
-from metatensor import Labels, LabelsEntry, TensorBlock, TensorMap
+import re
+import warnings
+
+import metatensor
+
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+
+
+Labels = metatensor.Labels
+LabelsEntry = metatensor.LabelsEntry
+TensorBlock = metatensor.TensorBlock
+TensorMap = metatensor.TensorMap
 
 
 def torch_jit_is_scripting():
     return False
 
 
-check_isinstance = isinstance
+_VERSION_REGEX = re.compile(r"(\d+)\.(\d+)\.*.")
 
-__all__ = [
-    "Labels",
-    "LabelsEntry",
-    "TensorBlock",
-    "TensorMap",
-    "torch_jit_is_scripting",
-    "check_isinstance",
-]
+
+def _version_at_least(version, expected):
+    version = tuple(map(int, _VERSION_REGEX.match(version).groups()))
+    expected = tuple(map(int, _VERSION_REGEX.match(expected).groups()))
+
+    return version >= expected
+
+
+def is_metatensor_class(value, typ):
+    assert typ in (Labels, TensorBlock, TensorMap)
+
+    if isinstance(value, typ):
+        return True
+    else:
+        if _HAS_TORCH and isinstance(value, torch.ScriptObject):
+            if _version_at_least(torch.__version__, "2.1.0"):
+                # _type() is only working for torch >= 2.1
+                is_metatensor_torch_class = "metatensor" in str(value._type())
+            else:
+                # we don't know, it's fine
+                is_metatensor_torch_class = False
+
+            if is_metatensor_torch_class:
+                warnings.warn(
+                    "Trying to use code from ``metatensor.learn`` with objects from "
+                    "metatensor-torch, you should use the code from "
+                    "`metatensor.torch.learn` instead",
+                    stacklevel=2,
+                )
+
+        return False

--- a/python/metatensor-learn/metatensor/learn/nn/sequential.py
+++ b/python/metatensor-learn/metatensor/learn/nn/sequential.py
@@ -3,7 +3,7 @@ from typing import List
 import torch
 from torch.nn import Module
 
-from .._backend import Labels, TensorMap, check_isinstance
+from .._backend import Labels, TensorMap, is_metatensor_class
 from .module_map import ModuleMap
 
 
@@ -21,7 +21,7 @@ class Sequential(Module):
 
     def __init__(self, in_keys: Labels, *args: List[ModuleMap]):
         super().__init__()
-        if not check_isinstance(in_keys, Labels):
+        if not is_metatensor_class(in_keys, Labels):
             raise TypeError("`in_keys` must be a `Labels` object.")
 
         modules: List[Module] = []

--- a/python/metatensor-operations/metatensor/operations/_dispatch.py
+++ b/python/metatensor-operations/metatensor/operations/_dispatch.py
@@ -799,6 +799,16 @@ def take(array, indices, axis: int):
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
+def make_like(array, like):
+    """Transform ``array`` to use the same backend/dtype/device as ``like``"""
+    if isinstance(like, TorchTensor):
+        return to(array, backend="torch", dtype=like.dtype, device=like.device)
+    if isinstance(like, np.ndarray):
+        return to(array, backend="numpy", dtype=like.dtype, device="cpu")
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
+
+
 def to(
     array,
     backend: Optional[str] = None,

--- a/python/metatensor-operations/metatensor/operations/add.py
+++ b/python/metatensor-operations/metatensor/operations/add.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -104,14 +104,14 @@ def add(A: TensorMap, B: Union[int, float, TensorMap]) -> TensorMap:
     """
 
     if not torch_jit_is_scripting():
-        if not check_isinstance(A, TensorMap):
+        if not is_metatensor_class(A, TensorMap):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     blocks: List[TensorBlock] = []
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = check_isinstance(B, TensorMap)
+        is_tensor_map = is_metatensor_class(B, TensorMap)
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor-operations/metatensor/operations/divide.py
+++ b/python/metatensor-operations/metatensor/operations/divide.py
@@ -4,7 +4,7 @@ from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -103,7 +103,7 @@ def _divide_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlo
 @torch_jit_script
 def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     if not torch_jit_is_scripting():
-        if not check_isinstance(A, TensorMap):
+        if not is_metatensor_class(A, TensorMap):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     r"""Return a new :class:`TensorMap` with the values being the element-wise
@@ -136,7 +136,7 @@ def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = check_isinstance(B, TensorMap)
+        is_tensor_map = is_metatensor_class(B, TensorMap)
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor-operations/metatensor/operations/drop_blocks.py
+++ b/python/metatensor-operations/metatensor/operations/drop_blocks.py
@@ -5,7 +5,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -29,12 +29,12 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
     """
     # Check arg types
     if not torch_jit_is_scripting():
-        if not check_isinstance(tensor, TensorMap):
+        if not is_metatensor_class(tensor, TensorMap):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
 
-        if not check_isinstance(keys, Labels):
+        if not is_metatensor_class(keys, Labels):
             raise TypeError(f"`keys` must be a metatensor Labels, not {type(keys)}")
 
         if not isinstance(copy, bool):

--- a/python/metatensor-operations/metatensor/operations/equal_metadata.py
+++ b/python/metatensor-operations/metatensor/operations/equal_metadata.py
@@ -7,7 +7,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -25,9 +25,9 @@ def _equal_metadata_impl(
     check: Union[List[str], str] = "all",
 ) -> str:
     if not torch_jit_is_scripting():
-        if not check_isinstance(tensor_1, TensorMap):
+        if not is_metatensor_class(tensor_1, TensorMap):
             return f"`tensor_1` must be a metatensor TensorMap, not {type(tensor_1)}"
-        if not check_isinstance(tensor_2, TensorMap):
+        if not is_metatensor_class(tensor_2, TensorMap):
             return f"`tensor_2` must be a metatensor TensorMap, not {type(tensor_2)}"
 
     message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
@@ -48,9 +48,9 @@ def _equal_metadata_block_impl(
     check: Union[List[str], str] = "all",
 ) -> str:
     if not torch_jit_is_scripting():
-        if not check_isinstance(block_1, TensorBlock):
+        if not is_metatensor_class(block_1, TensorBlock):
             return f"`block_1` must be a metatensor TensorBlock, not {type(block_1)}"
-        if not check_isinstance(block_2, TensorBlock):
+        if not is_metatensor_class(block_2, TensorBlock):
             return f"`block_2` must be a metatensor TensorBlock, not {type(block_2)}"
 
     check_blocks_message = _check_blocks_impl(

--- a/python/metatensor-operations/metatensor/operations/join.py
+++ b/python/metatensor-operations/metatensor/operations/join.py
@@ -5,7 +5,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -353,7 +353,7 @@ def join(
             raise TypeError(f"`tensor` must be a list or a tuple, not {type(tensors)}")
 
         for tensor in tensors:
-            if not check_isinstance(tensor, TensorMap):
+            if not is_metatensor_class(tensor, TensorMap):
                 raise TypeError(
                     "`tensors` elements must be metatensor TensorMap, "
                     f"not {type(tensor)}"

--- a/python/metatensor-operations/metatensor/operations/multiply.py
+++ b/python/metatensor-operations/metatensor/operations/multiply.py
@@ -4,7 +4,7 @@ from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -124,14 +124,14 @@ def multiply(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not check_isinstance(A, TensorMap):
+        if not is_metatensor_class(A, TensorMap):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     blocks: List[TensorBlock] = []
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = check_isinstance(B, TensorMap)
+        is_tensor_map = is_metatensor_class(B, TensorMap)
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor-operations/metatensor/operations/pow.py
+++ b/python/metatensor-operations/metatensor/operations/pow.py
@@ -4,7 +4,7 @@ from . import _dispatch
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -77,7 +77,7 @@ def pow(A: TensorMap, B: Union[float, int]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not check_isinstance(A, TensorMap):
+        if not is_metatensor_class(A, TensorMap):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
         if not isinstance(B, (float, int)):

--- a/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
+++ b/python/metatensor-operations/metatensor/operations/reduce_over_samples.py
@@ -171,7 +171,7 @@ def _reduce_over_samples_block(
     values_mean = _dispatch.empty_like(values_result, [0])
 
     if reduction == "mean" or reduction == "std" or reduction == "var":
-        bincount = _dispatch.bincount(index)
+        bincount = _dispatch.make_like(_dispatch.bincount(index), values_result)
         values_result = values_result / bincount.reshape(
             (-1,) + (1,) * len(other_shape)
         )

--- a/python/metatensor-operations/metatensor/operations/slice.py
+++ b/python/metatensor-operations/metatensor/operations/slice.py
@@ -6,7 +6,7 @@ from ._backend import (
     LabelsValues,
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -26,7 +26,7 @@ def _slice_block(
     else:
         if not torch_jit_is_scripting():
             # This should already have been checked
-            assert check_isinstance(selection, Labels)
+            assert is_metatensor_class(selection, Labels)
 
         if axis == "samples":
             selected = block.samples.select(selection)
@@ -168,7 +168,7 @@ def _check_slice_args(
             raise ValueError("`selection` must be a 1-D array of integers")
     elif not isinstance(selection, list):
         if not torch_jit_is_scripting():
-            if not check_isinstance(selection, Labels):
+            if not is_metatensor_class(selection, Labels):
                 raise TypeError(
                     "`selection` must be metatensor Labels, an array "
                     + f"or List[int], not {type(selection)}"
@@ -223,7 +223,7 @@ def slice(tensor: TensorMap, axis: str, selection: Labels) -> TensorMap:
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not check_isinstance(tensor, TensorMap):
+        if not is_metatensor_class(tensor, TensorMap):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -266,7 +266,7 @@ def slice_block(
     :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced input.
     """
     if not torch_jit_is_scripting():
-        if not check_isinstance(block, TensorBlock):
+        if not is_metatensor_class(block, TensorBlock):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor-operations/metatensor/operations/split.py
+++ b/python/metatensor-operations/metatensor/operations/split.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from ._backend import (
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -144,7 +144,7 @@ def split(
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not check_isinstance(tensor, TensorMap):
+        if not is_metatensor_class(tensor, TensorMap):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -253,7 +253,7 @@ def split_block(
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not check_isinstance(block, TensorBlock):
+        if not is_metatensor_class(block, TensorBlock):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor-operations/metatensor/operations/subtract.py
+++ b/python/metatensor-operations/metatensor/operations/subtract.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from ._backend import (
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -37,13 +37,13 @@ def subtract(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not check_isinstance(A, TensorMap):
+        if not is_metatensor_class(A, TensorMap):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = check_isinstance(B, TensorMap)
+        is_tensor_map = is_metatensor_class(B, TensorMap)
 
     if isinstance(B, (float, int)):
         B = -float(B)

--- a/python/metatensor-operations/metatensor/operations/unique_metadata.py
+++ b/python/metatensor-operations/metatensor/operations/unique_metadata.py
@@ -9,7 +9,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    check_isinstance,
+    is_metatensor_class,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -164,7 +164,7 @@ def unique_metadata(
     """
     # Parse input args
     if not torch_jit_is_scripting():
-        if not check_isinstance(tensor, TensorMap):
+        if not is_metatensor_class(tensor, TensorMap):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -224,7 +224,7 @@ def unique_metadata_block(
     """
     # Parse input args
     if not torch_jit_is_scripting():
-        if not check_isinstance(block, TensorBlock):
+        if not is_metatensor_class(block, TensorBlock):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor-torch/metatensor/torch/atomistic/systems_to_torch.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/systems_to_torch.py
@@ -106,15 +106,14 @@ def _system_to_torch(
         device=device,
     )
 
-    cell_vectors_are_not_zero = np.any(system.cell == 0, axis=1)
-
+    cell_vectors_are_not_zero = np.any(system.cell != 0, axis=1)
     if not np.all(cell_vectors_are_not_zero == system.pbc):
         warnings.warn(
             "A conversion to `System` was requested for an `ase.Atoms` object "
             "with one or more non-zero cell vectors but where the corresponding "
             "boundary conditions are set to `False`. "
             "The corresponding cell vectors will be set to zero.",
-            stacklevel=2,
+            stacklevel=3,
         )
 
     cell = torch.zeros((3, 3), dtype=dtype, device=device)

--- a/python/metatensor-torch/metatensor/torch/learn.py
+++ b/python/metatensor-torch/metatensor/torch/learn.py
@@ -27,19 +27,23 @@ module.__dict__["TensorMap"] = TensorMap
 module.__dict__["torch_jit_is_scripting"] = torch.jit.is_scripting
 
 
-def check_isinstance(obj, ty):
-    if isinstance(ty, torch.ScriptClass):
-        # This branch is taken when `ty` is a custom class (TensorMap, …). since `ty` is
-        # an instance of `torch.ScriptClass` and not a class itself, there is no way to
-        # check if obj is an "instance" of this class, so we always return True and hope
-        # for the best. Most errors should be caught by the TorchScript compiler anyway.
+def is_metatensor_class(value, typ):
+    if torch.jit.is_scripting():
+        return True
+
+    assert typ in (Labels, LabelsEntry, TensorBlock, TensorMap)
+    if isinstance(value, torch.ScriptObject):
+        # For custom classes (TensorMap, …), the `typ` is an instance of
+        # `torch.ScriptClass` and not a class itself, and there is no way to check
+        # if obj is an "instance" of this class; so we always return True and hope
+        # for the best. Most errors should be caught by the TorchScript compiler
+        # anyway.
         return True
     else:
-        assert isinstance(ty, type)
-        return isinstance(obj, ty)
+        return False
 
 
-module.__dict__["check_isinstance"] = check_isinstance
+module.__dict__["is_metatensor_class"] = is_metatensor_class
 
 # register the module in sys.modules, so future import find it directly
 sys.modules[spec.name] = module

--- a/python/metatensor-torch/tests/atomistic/model.py
+++ b/python/metatensor-torch/tests/atomistic/model.py
@@ -288,6 +288,7 @@ def test_access_module(tmpdir):
     model.train(False)
 
     capabilities = ModelCapabilities(
+        length_unit="nm",
         interaction_range=0.0,
         supported_devices=["cpu"],
         dtype="float64",
@@ -314,6 +315,7 @@ def test_is_atomistic_model(tmpdir):
     model.train(False)
 
     capabilities = ModelCapabilities(
+        length_unit="A",
         interaction_range=0.0,
         supported_devices=["cpu"],
         dtype="float64",
@@ -338,6 +340,7 @@ def test_read_metadata(tmpdir):
     model.train(False)
 
     capabilities = ModelCapabilities(
+        length_unit="nm",
         interaction_range=0.0,
         supported_devices=["cpu"],
         dtype="float64",

--- a/python/metatensor-torch/tests/operations/add.py
+++ b/python/metatensor-torch/tests/operations/add.py
@@ -1,24 +1,48 @@
 import io
 import os
 
+import pytest
 import torch
+from packaging import version
 
+import metatensor
 import metatensor.torch
 
 
-def test_add():
-    tensor = metatensor.torch.load(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "metatensor-operations",
-            "tests",
-            "data",
-            "qm7-power-spectrum.npz",
-        )
+@pytest.fixture
+def tensor_path():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "metatensor-operations",
+        "tests",
+        "data",
+        "qm7-power-spectrum.npz",
     )
+
+
+def test_type_error(tensor_path):
+    # using operations from metatensor-core with type from metatensor-torch
+    tensor = metatensor.torch.load(tensor_path)
+    error = "`A` must be a metatensor TensorMap, not <class 'torch.ScriptObject'>"
+    warning = (
+        "Trying to use operations from metatensor with objects from metatensor-torch, "
+        "you should use the operation from `metatensor.torch` as well, e.g. "
+        r"`metatensor.torch.add\(...\)` instead of `metatensor.add\(...\)`"
+    )
+    with pytest.raises(TypeError, match=error):
+        if version.parse(torch.__version__) >= version.parse("2.1"):
+            with pytest.warns(UserWarning, match=warning):
+                metatensor.add(tensor, tensor)
+        else:
+            # no warning before torch 2.1
+            metatensor.add(tensor, tensor)
+
+
+def test_add(tensor_path):
+    tensor = metatensor.torch.load(tensor_path)
     sum_tensor = metatensor.torch.add(tensor, tensor)
     assert metatensor.torch.equal_metadata(sum_tensor, tensor)
     assert metatensor.torch.allclose(sum_tensor, metatensor.torch.multiply(tensor, 2))


### PR DESCRIPTION
We can not warn the other way around, since the TorchScript Python runtime will try to do a cast before we even get to our own code.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2113032313.zip)

<!-- download-section Documentation end -->