### PR TITLE
Use ruff instead of blackdoc to format examples in docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,6 @@ ignore = ["B018", "B904"]
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 known-first-party = ["metatensor"]
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/python/metatensor-core/metatensor/labels.py
+++ b/python/metatensor-core/metatensor/labels.py
@@ -234,7 +234,6 @@ class Labels:
     [0 1 8]
     >>> for entry in labels:
     ...     print(entry)
-    ...
     LabelsEntry(system=0, atom=1, center_type=8)
     LabelsEntry(system=0, atom=2, center_type=1)
     LabelsEntry(system=0, atom=5, center_type=1)
@@ -694,7 +693,6 @@ class Labels:
         ...     label.remove(name="bar")
         ... except MetatensorError as e:
         ...     print(e)
-        ...
         invalid parameter: can not have the same label entry multiple time: [42] is already present
         """  # noqa E501
         if name not in self.names:

--- a/python/metatensor-learn/metatensor/learn/data/dataset.py
+++ b/python/metatensor-learn/metatensor/learn/data/dataset.py
@@ -130,13 +130,11 @@ class Dataset(_BaseDataset):
     >>> # iterating over a dataset
     >>> for num, called in dataset:
     ...     print(num, " -- ", called)
-    ...
     1  --  compute something with sample 0
     2  --  compute something with sample 1
     3  --  compute something with sample 2
     >>> for sample in dataset:
     ...     print(sample.num, " -- ", sample.call_me)
-    ...
     1  --  compute something with sample 0
     2  --  compute something with sample 1
     3  --  compute something with sample 2

--- a/python/metatensor-learn/metatensor/learn/nn/module_map.py
+++ b/python/metatensor-learn/metatensor/learn/nn/module_map.py
@@ -105,7 +105,6 @@ class ModuleMap(ModuleList):
         >>> linear = torch.nn.Linear(3, 1, bias=False)
         >>> with torch.no_grad():
         ...     _ = linear.weight.copy_(torch.tensor([1.0, 1.0, 1.0]))
-        ...
         >>> modules = [linear, deepcopy(linear)]
         >>> # you could also extend the module by some nonlinear activation function
 
@@ -229,7 +228,6 @@ class ModuleMap(ModuleList):
         >>> linear = torch.nn.Linear(3, 1, bias=False)
         >>> with torch.no_grad():
         ...     _ = linear.weight.copy_(torch.tensor([1.0, 1.0, 1.0]))
-        ...
         >>> # you could also extend the module by some nonlinear activation function
         >>> from metatensor.learn.nn import ModuleMap
         >>> module_map = ModuleMap.from_module(tensor.keys, linear)

--- a/python/metatensor-operations/metatensor/operations/_checks.py
+++ b/python/metatensor-operations/metatensor/operations/_checks.py
@@ -66,7 +66,6 @@ class unsafe_enable_checks(_SetChecks):
     ...     with metatensor.unsafe_enable_checks():
     ...         # checks enabled here again
     ...         print(metatensor.checks_enabled())
-    ...
     False
     True
     >>> print(metatensor.checks_enabled())
@@ -95,7 +94,6 @@ class unsafe_disable_checks(_SetChecks):
     >>> with metatensor.unsafe_disable_checks():
     ...     # checks are disabled here
     ...     print(metatensor.checks_enabled())
-    ...
     False
     >>> print(metatensor.checks_enabled())
     True

--- a/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
+++ b/python/metatensor-operations/metatensor/operations/manipulate_dimension.py
@@ -334,7 +334,6 @@ def remove_dimension(tensor: TensorMap, axis: str, name: str) -> TensorMap:
     ...     metatensor.remove_dimension(tensor, axis="keys", name="extra")
     ... except MetatensorError as e:
     ...     print(e)
-    ...
     invalid parameter: can not have the same label entry multiple time: [0] is already present
     """  # noqa E501
     _check_axis(axis)

--- a/python/metatensor-torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor-torch/metatensor/torch/atomistic/model.py
@@ -215,7 +215,6 @@ class MetatensorAtomisticModel(torch.nn.Module):
     ...             )
     ...
     ...         return results
-    ...
 
     Wrapping and exporting this model would then look like this:
 
@@ -257,7 +256,6 @@ class MetatensorAtomisticModel(torch.nn.Module):
     >>> # save the exported model to disk
     >>> with tempfile.TemporaryDirectory() as directory:
     ...     model.save(os.path.join(directory, "constant-energy-model.pt"))
-    ...
 
     .. py:attribute:: module
         :type: ModelInterface

--- a/python/metatensor-torch/metatensor/torch/documentation.py
+++ b/python/metatensor-torch/metatensor/torch/documentation.py
@@ -154,7 +154,6 @@ class Labels:
     tensor([0, 1, 8], dtype=torch.int32)
     >>> for entry in labels:
     ...     print(entry)
-    ...
     LabelsEntry(system=0, atom=1, type=8)
     LabelsEntry(system=0, atom=2, type=1)
     LabelsEntry(system=0, atom=5, type=1)
@@ -490,7 +489,6 @@ class Labels:
         ...     label.remove(name="bar")
         ... except RuntimeError as e:
         ...     print(e)
-        ...
         invalid parameter: can not have the same label entry multiple time: [42] is already present
         """  # noqa E501
 

--- a/tox.ini
+++ b/tox.ini
@@ -221,12 +221,10 @@ description = Run linters and type checks
 package = skip
 deps =
     ruff
-    blackdoc
 
 commands =
     ruff format --diff {[testenv]lint_folders}
     ruff check {[testenv]lint_folders}
-    blackdoc --check --diff {[testenv]lint_folders}
 
 
 [testenv:format]
@@ -234,9 +232,7 @@ description = Abuse tox to do actual formatting on all files.
 package = skip
 deps =
     ruff
-    blackdoc
 commands =
-    blackdoc {[testenv]lint_folders}
     ruff format {[testenv]lint_folders}
     ruff check --fix-only {[testenv]lint_folders}
 


### PR DESCRIPTION
This is a follow-up to #747, also replacing `blackdoc` with ruff.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2145915030.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2146066398.zip)

<!-- download-section Build Python wheels end -->