### PR TITLE
Make sure to serialize NeighborListOptions.requestors

### DIFF
--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -96,6 +96,8 @@ std::string NeighborListOptionsHolder::to_json() const {
     result["strict"] = this->strict_;
     result["length_unit"] = this->length_unit_;
 
+    result["requestors"] = this->requestors_;
+
     return result.dump(/*indent*/4, /*indent_char*/' ', /*ensure_ascii*/ true);
 }
 
@@ -125,7 +127,7 @@ NeighborListOptions NeighborListOptionsHolder::from_json(const std::string& json
         throw std::runtime_error("'full_list' in JSON for NeighborListOptions must be a boolean");
     }
     auto full_list = data["full_list"].get<bool>();
-    
+
     if (!data.contains("strict") || !data["strict"].is_boolean()) {
         throw std::runtime_error("'strict' in JSON for NeighborListOptions must be a boolean");
     }
@@ -138,6 +140,20 @@ NeighborListOptions NeighborListOptionsHolder::from_json(const std::string& json
             throw std::runtime_error("'length_unit' in JSON for NeighborListOptions must be a string");
         }
         options->set_length_unit(data["length_unit"]);
+    }
+
+    if (data.contains("requestors")) {
+        if (!data["requestors"].is_array()) {
+            throw std::runtime_error("'requestors' in JSON for NeighborListOptions must be an array");
+        }
+
+        for (const auto& requestor: data["requestors"]) {
+            if (!requestor.is_string()) {
+                throw std::runtime_error("'requestors' in JSON for NeighborListOptions must be an array of strings");
+            }
+
+            options->add_requestor(requestor.get<std::string>());
+        }
     }
 
     return options;

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -13,13 +13,20 @@ TEST_CASE("Models metadata") {
         auto options = torch::make_intrusive<NeighborListOptionsHolder>(
             /*cutoff=*/ 3.5426,
             /*full_list=*/ true,
-            /*strict=*/ true
+            /*strict=*/ true,
+            /*requestor=*/ "request"
         );
+        options->add_requestor("another request");
+
         const auto* expected = R"({
     "class": "NeighborListOptions",
     "cutoff": 4615159644819978768,
     "full_list": true,
     "length_unit": "",
+    "requestors": [
+        "request",
+        "another request"
+    ],
     "strict": true
 })";
         CHECK(options->to_json() == expected);
@@ -29,12 +36,14 @@ TEST_CASE("Models metadata") {
     "cutoff": 4615159644819978768,
     "full_list": false,
     "strict": false,
-    "class": "NeighborListOptions"
+    "class": "NeighborListOptions",
+    "requestors": ["some request", "hello.world"]
 })";
         options = NeighborListOptionsHolder::from_json(json);
         CHECK(options->cutoff() == 3.5426);
         CHECK(options->full_list() == false);
         CHECK(options->strict() == false);
+        CHECK(options->requestors() == std::vector<std::string>{"some request", "hello.world"});
 
         CHECK_THROWS_WITH(
             NeighborListOptionsHolder::from_json("{}"),


### PR DESCRIPTION
This is used among other by rascaline to know which NL it requested and convert them to the internal format. It looks like I forgot to add serialization for these, meaning that the models using rascaline would only re-use NL when running in pure Python mode, and not through TorchScript. In the other cases, rascaline would recompute the NL, hiding the issue, until someone tried to run the model in LAMMPS where we can not recompute the NL.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2147405572.zip)

<!-- download-section Documentation end -->