### PR TITLE
Fix external build, and add CI job to check them

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -24,9 +24,6 @@ concurrency:
   group: python-wheels-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-env:
-  METATENSOR_NO_LOCAL_DEPS: "1"
-
 
 jobs:
   build-core-wheels:
@@ -297,6 +294,8 @@ jobs:
   build-others:
     name: Build other wheels/sdists
     runs-on: ubuntu-22.04
+    env:
+      METATENSOR_NO_LOCAL_DEPS: "1"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -427,3 +426,79 @@ jobs:
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-build-external:
+    # This checks building the wheels with external libraries. This setup is
+    # mainly used for the conda packages metatensor-*-python, which use the
+    # libmetatensor-* conda packages to provide the native code.
+    runs-on: ${{ matrix.os }}
+    name: External libraries / ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            rust-target: x86_64-unknown-linux-gnu
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.5.1%2Bcpu.zip
+          - os: macos-14
+            rust-target: aarch64-apple-darwin
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.5.1.zip
+          - os: windows-2019
+            rust-target: x86_64-pc-windows-msvc
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.5.1%2Bcpu.zip
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: ${{ matrix.rust-target }}
+
+      - name: setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: setup environment
+        run: |
+          pip install build
+          echo "CMAKE_PREFIX_PATH=${RUNNER_TEMP//\\//}/usr" >> "$GITHUB_ENV"
+
+      - name: setup libtorch
+        run: |
+          curl --output libtorch.zip ${{ matrix.libtorch-url }}
+          unzip -q libtorch.zip -d $CMAKE_PREFIX_PATH/
+          mv $CMAKE_PREFIX_PATH/libtorch/* $CMAKE_PREFIX_PATH/
+
+      - name: build libmetatensor
+        run: |
+          cmake -B build-metatensor-core -S metatensor-core -DMETATENSOR_INSTALL_BOTH_STATIC_SHARED=OFF -DCMAKE_INSTALL_PREFIX=$CMAKE_PREFIX_PATH -DCMAKE_BUILD_TYPE=Debug
+          cmake --build build-metatensor-core --config Debug
+          cmake --install build-metatensor-core --config Debug
+
+      - name: build libmetatensor-torch
+        run: |
+          cmake -B build-metatensor-torch -S metatensor-torch -DCMAKE_INSTALL_PREFIX=$CMAKE_PREFIX_PATH -DCMAKE_BUILD_TYPE=Debug
+          cmake --build build-metatensor-torch --config Debug
+          cmake --install build-metatensor-torch --config Debug
+
+      - name: build metatensor-core wheels
+        run: |
+          python -m build python/metatensor_core --wheel --outdir=dist/
+          # check that the wheel is using an external library
+          unzip -l dist/metatensor_core*.whl | grep "_external.py"
+        env:
+          METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB: "ON"
+
+      - name: build metatensor-torch wheels
+        run: |
+          python -m build python/metatensor_torch --wheel --outdir=dist/
+          unzip -l dist/metatensor_torch*.whl | grep "_external.py"
+        env:
+          METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB: "ON"
+          METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB: "ON"

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up Python ${{ matrix.python-version }}
+      - name: setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/python/metatensor_core/CMakeLists.txt
+++ b/python/metatensor_core/CMakeLists.txt
@@ -16,6 +16,15 @@ file(REMOVE ${CMAKE_INSTALL_PREFIX}/_external.py)
 
 set(REQUIRED_METATENSOR_VERSION "0.1.11")
 if(${METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB})
+    # when building a source checkout, update version to include git information
+    # this will not apply when building a sdist
+    if (EXISTS ${CMAKE_SOURCE_DIR}/../../metatensor-core/cmake/dev-versions.cmake)
+        include(${CMAKE_SOURCE_DIR}/../../metatensor-core/cmake/dev-versions.cmake)
+        create_development_version("${REQUIRED_METATENSOR_VERSION}" REQUIRED_METATENSOR_VERSION "metatensor-core-v")
+        # strip any -dev/-rc suffix on the version since find_package does not support it
+        string(REGEX REPLACE "([0-9]*)\\.([0-9]*)\\.([0-9]*).*" "\\1.\\2.\\3" REQUIRED_METATENSOR_VERSION ${REQUIRED_METATENSOR_VERSION})
+    endif()
+
     find_package(metatensor ${REQUIRED_METATENSOR_VERSION} REQUIRED)
 
     get_target_property(METATENSOR_LOCATION metatensor::shared LOCATION)

--- a/python/metatensor_torch/CMakeLists.txt
+++ b/python/metatensor_torch/CMakeLists.txt
@@ -14,8 +14,25 @@ set(METATENSOR_TORCH_SOURCE_DIR "" CACHE PATH "Path to the sources of metatensor
 
 file(REMOVE ${CMAKE_INSTALL_PREFIX}/_external.py)
 
-set(REQUIRED_METATENSOR_TORCH_VERSION "1")
+set(REQUIRED_METATENSOR_TORCH_VERSION "0.6.1")
 if(${METATENSOR_TORCH_PYTHON_USE_EXTERNAL_LIB})
+    # when building a source checkout, update version to include git information
+    # this will not apply when building a sdist
+    if (EXISTS ${CMAKE_SOURCE_DIR}/../../metatensor-torch/cmake/dev-versions.cmake)
+        include(${CMAKE_SOURCE_DIR}/../../metatensor-torch/cmake/dev-versions.cmake)
+        create_development_version(
+            "${REQUIRED_METATENSOR_TORCH_VERSION}"
+            REQUIRED_METATENSOR_TORCH_VERSION
+            "metatensor-torch-v"
+        )
+        # strip any -dev/-rc suffix on the version since find_package does not support it
+        string(
+            REGEX REPLACE "([0-9]*)\\.([0-9]*)\\.([0-9]*).*" "\\1.\\2.\\3"
+            REQUIRED_METATENSOR_TORCH_VERSION
+            ${REQUIRED_METATENSOR_TORCH_VERSION}
+        )
+    endif()
+
     find_package(metatensor_torch ${REQUIRED_METATENSOR_TORCH_VERSION} REQUIRED)
 
     get_target_property(METATENSOR_TORCH_LOCATION metatensor_torch LOCATION)


### PR DESCRIPTION
An unwanted change was included in release 0.6.1 of metatensor-torch, related to the code that enables building Python wheels against an already existing libmetatensor/libmetatensor-torch. These are intended to be used for the conda release (cf #402 and #729), and where not tested before.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2284266379.zip)

<!-- download-section Documentation end -->

<!-- download-section Build Python wheels start -->
⚙️ [Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2295095845.zip)

<!-- download-section Build Python wheels end -->