### PR TITLE
Do not crash when selecting from an empty set of Labels

### DIFF
--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -615,6 +615,10 @@ torch::Tensor LabelsHolder::select(const TorchLabels& selection) const {
     auto selected = torch::zeros({this->count()}, options);
     auto selected_count = static_cast<size_t>(selected.size(0));
 
+    if (this->count() == 0) {
+        return selected;
+    }
+
     labels_->select(
         selection->labels_.value(),
         selected.data_ptr<int64_t>(),

--- a/python/metatensor-core/tests/labels.py
+++ b/python/metatensor-core/tests/labels.py
@@ -432,3 +432,8 @@ def test_select():
     message = "invalid parameter: 'aaaa' in selection is not part of these Labels"
     with pytest.raises(MetatensorError, match=message):
         labels.select(selection)
+
+    # empty labels
+    labels = Labels(["aa", "bb"], np.empty((0, 2), dtype=np.int32))
+    selection = Labels(["aa"], np.array([[1], [2], [5]]))
+    assert len(labels.select(selection)) == 0

--- a/python/metatensor-torch/tests/labels.py
+++ b/python/metatensor-torch/tests/labels.py
@@ -502,6 +502,11 @@ def test_select():
     with pytest.raises(RuntimeError, match=message):
         labels.select(selection)
 
+    # empty labels
+    labels = Labels(["aa", "bb"], torch.empty((0, 2), dtype=torch.int32))
+    selection = Labels(["aa"], torch.tensor([[1], [2], [5]]))
+    assert len(labels.select(selection)) == 0
+
 
 # define a wrapper class to make sure the types TorchScript uses for of all
 # C-defined functions matches what we expect


### PR DESCRIPTION
The torch code would previously fail with `invalid parameter: got invalid NULL pointer for selected at metatensor-core/src/c_api/labels.rs:556`

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation start -->

----
 📚 [Download documentation preview for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2177989480.zip)

<!-- download-section Documentation end -->