### PR TITLE
Small improvements to the speed of metatensor-core Python bindings

### DIFF
--- a/python/metatensor_core/metatensor/block.py
+++ b/python/metatensor_core/metatensor/block.py
@@ -10,10 +10,10 @@ from ._c_api import c_uintptr_t, mts_array_t, mts_block_t, mts_labels_t
 from ._c_lib import _get_library
 from .data import (
     Array,
-    ArrayWrapper,
     Device,
     DeviceWarning,
     DType,
+    create_mts_array,
     mts_array_to_python_array,
 )
 from .labels import Labels
@@ -108,11 +108,9 @@ class TensorBlock:
         for i, component in enumerate(components):
             components_array[i] = component._as_mts_labels_t()
 
-        original_values = values
-        values = ArrayWrapper(values)
-
+        mts_array = create_mts_array(values)
         self._actual_ptr = self._lib.mts_block(
-            values.into_mts_array(),
+            mts_array,
             samples._as_mts_labels_t(),
             components_array,
             len(components_array),
@@ -120,10 +118,10 @@ class TensorBlock:
         )
         _check_pointer(self._actual_ptr)
 
-        self._cached_dtype = data.array_dtype(original_values)
-        self._cached_device = data.array_device(original_values)
+        self._cached_dtype = data.array_dtype(values)
+        self._cached_device = data.array_device(values)
 
-        if not data.array_device_is_cpu(original_values):
+        if not data.array_device_is_cpu(values):
             warnings.warn(
                 "Values and labels for this block are on different devices: "
                 f"labels are always on CPU, and values are on device '{self.device}'. "

--- a/python/metatensor_core/metatensor/data/__init__.py
+++ b/python/metatensor_core/metatensor/data/__init__.py
@@ -1,16 +1,16 @@
-from .array import (  # noqa
-    ArrayWrapper,
+from .array import (  # noqa: F401
     Device,
-    DType,
     DeviceWarning,
-    array_device,
-    array_change_device,
-    array_dtype,
-    array_change_dtype,
-    array_device_is_cpu,
+    DType,
     array_change_backend,
+    array_change_device,
+    array_change_dtype,
+    array_device,
+    array_device_is_cpu,
+    array_dtype,
+    create_mts_array,
 )
-from .extract import (  # noqa
+from .extract import (  # noqa: F401
     Array,
     ExternalCpuArray,
     data_origin,

--- a/python/metatensor_core/metatensor/data/extract.py
+++ b/python/metatensor_core/metatensor/data/extract.py
@@ -6,7 +6,12 @@ import numpy as np
 from .._c_api import c_uintptr_t, mts_array_t, mts_data_origin_t
 from ..status import _check_status
 from ..utils import _call_with_growing_buffer, _ptr_to_ndarray
-from .array import _object_from_ptr, _origin_numpy, _origin_pytorch, _register_origin
+from .array import (
+    _KNOWN_ARRAY_WRAPPERS,
+    _origin_numpy,
+    _origin_pytorch,
+    _register_origin,
+)
 
 
 try:
@@ -77,7 +82,7 @@ def mts_array_to_python_array(mts_array, parent=None):
     """
     origin = data_origin(mts_array)
     if _is_python_origin(origin):
-        return _object_from_ptr(mts_array.ptr).array
+        return _KNOWN_ARRAY_WRAPPERS[mts_array.ptr].array
     elif origin in _ADDITIONAL_ORIGINS:
         return _ADDITIONAL_ORIGINS[origin](mts_array, parent=parent)
     else:

--- a/python/metatensor_core/metatensor/io/_block.py
+++ b/python/metatensor_core/metatensor/io/_block.py
@@ -11,7 +11,7 @@ import numpy as np
 from .._c_api import c_uintptr_t, mts_array_t, mts_create_array_callback_t
 from .._c_lib import _get_library
 from ..block import TensorBlock
-from ..data.array import ArrayWrapper, _is_numpy_array, _is_torch_array
+from ..data.array import _is_numpy_array, _is_torch_array, create_mts_array
 from ..utils import catch_exceptions
 from ._labels import _labels_from_mts, _labels_to_mts
 from ._utils import _save_buffer_raw
@@ -36,8 +36,7 @@ def create_numpy_array(shape_ptr, shape_count, array):
         shape.append(shape_ptr[i])
 
     data = np.empty(shape, dtype=np.float64)
-    wrapper = ArrayWrapper(data)
-    array[0] = wrapper.into_mts_array()
+    array[0] = create_mts_array(data)
 
 
 @catch_exceptions
@@ -55,8 +54,7 @@ def create_torch_array(shape_ptr, shape_count, array):
         shape.append(shape_ptr[i])
 
     data = torch.empty(shape, dtype=torch.float64, device="cpu")
-    wrapper = ArrayWrapper(data)
-    array[0] = wrapper.into_mts_array()
+    array[0] = create_mts_array(data)
 
 
 def load_block(

--- a/python/metatensor_core/setup.py
+++ b/python/metatensor_core/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.sdist import sdist
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
 
-METATENSOR_BUILD_TYPE = os.environ.get("METATENSOR_BUILD_TYPE", "release")
+METATENSOR_BUILD_TYPE = os.environ.get("METATENSOR_BUILD_TYPE", "debug")
 if METATENSOR_BUILD_TYPE not in ["debug", "release"]:
     raise Exception(
         f"invalid build type passed: '{METATENSOR_BUILD_TYPE}', "


### PR DESCRIPTION
Triggered by #818 

Using the script in the issue, on main:

```
numpy-cpu l_max=10: sphericart is 0.59ms, sphericart.metatensor is 2.04ms
```

With this PR:
```
numpy-cpu l_max=10: sphericart is 0.61ms, sphericart.metatensor is 1.55ms
```

There are still a lot more improvement to add, but these are the one I found with line_profiler.

The current profile is 

```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    81                                               @profile
    82                                               def compute_with_gradients(self, xyz: TensorMap) -> TensorMap:
    83                                                   """
    84                                                   Computes the spherical harmonics for the given Cartesian coordinates, up to
    85                                                   the maximum degree ``l_max`` specified during initialization,
    86                                                   together with their gradients with respect to the Cartesian coordinates.
    87
    88                                                   :param xyz: see :py:meth:`compute`
    89
    90                                                   :return: The spherical harmonics and their metadata as a
    91                                                       :py:class:`metatensor.TensorMap`. Each ``TensorBlock`` in the output
    92                                                       ``TensorMap`` will have a gradient block with respect to the Cartesian
    93                                                       positions. All ``samples`` in the output ``TensorMap`` will be the same as
    94                                                       those of the ``xyz`` input.
    95                                                   """
    96      1100     299792.0    272.5     13.8          _check_xyz_tensor_map(xyz)
    97      2200     834594.0    379.4     38.3          sh_values, sh_gradients = self.raw_calculator.compute_with_gradients(
    98      1100      57123.0     51.9      2.6              xyz.block().values.squeeze(-1)
    99                                                   )
   100      2200     885636.0    402.6     40.7          return _wrap_into_tensor_map(
   101      1100        102.0      0.1      0.0              sh_values,
   102      1100        270.0      0.2      0.0              self.precomputed_keys,
   103      1100     100327.0     91.2      4.6              xyz.block().samples,
   104      1100        137.0      0.1      0.0              self.precomputed_mu_components,
   105      1100         74.0      0.1      0.0              self.precomputed_xyz_components,
   106      1100         87.0      0.1      0.0              self.precomputed_xyz_2_components,
   107      1100         82.0      0.1      0.0              self.precomputed_properties,
   108      1100         84.0      0.1      0.0              sh_gradients,
   109                                                   )
```

Where `_check_xyz_tensor_map` accounts for 14% of the runtime, and `_wrap_into_tensor_map` for 40%. The profile for `_wrap_into_tensor_map` is 

```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   246                                           @profile
   247                                           def _wrap_into_tensor_map(
   248                                               sh_values: np.ndarray,
   249                                               keys: Labels,
   250                                               samples: Labels,
   251                                               components: List[Labels],
   252                                               xyz_components: Labels,
   253                                               xyz_2_components: Labels,
   254                                               properties: Labels,
   255                                               sh_gradients: Optional[np.ndarray] = None,
   256                                               sh_hessians: Optional[np.ndarray] = None,
   257                                           ) -> TensorMap:
   258
   259                                               # infer l_max
   260      1100        492.0      0.4      0.1      l_max = len(components) - 1
   261
   262      1100        130.0      0.1      0.0      blocks = []
   263     13200       1970.0      0.1      0.2      for l in range(l_max + 1):  # noqa E741
   264     12100       2129.0      0.2      0.3          l_start = l**2
   265     12100       1576.0      0.1      0.2          l_end = (l + 1) ** 2
   266     24200     155968.0      6.4     18.7          sh_values_block = TensorBlock(
   267     12100       5014.0      0.4      0.6              values=sh_values[:, l_start:l_end, None],
   268     12100       1106.0      0.1      0.1              samples=samples,
   269     12100       1790.0      0.1      0.2              components=[components[l]],
   270     12100       1167.0      0.1      0.1              properties=properties,
   271                                                   )
   272     12100       1430.0      0.1      0.2          if sh_gradients is not None:
   273     24200     162492.0      6.7     19.5              sh_gradients_block = TensorBlock(
   274     12100       5138.0      0.4      0.6                  values=sh_gradients[:, :, l_start:l_end, None],
   275     12100       1077.0      0.1      0.1                  samples=samples,
   276     12100       1513.0      0.1      0.2                  components=[xyz_components, components[l]],
   277     12100       1001.0      0.1      0.1                  properties=properties,
   278                                                       )
   279     12100       1619.0      0.1      0.2              if sh_hessians is not None:
   280                                                           sh_hessians_block = TensorBlock(
   281                                                               values=sh_hessians[:, :, :, l_start:l_end, None],
   282                                                               samples=samples,
   283                                                               components=[
   284                                                                   xyz_2_components,
   285                                                                   xyz_components,
   286                                                                   components[l],
   287                                                               ],
   288                                                               properties=properties,
   289                                                           )
   290                                                           sh_gradients_block.add_gradient("positions", sh_hessians_block)
   291     12100     357712.0     29.6     43.0              sh_values_block.add_gradient("positions", sh_gradients_block)
   292
   293     12100       1506.0      0.1      0.2          blocks.append(sh_values_block)
   294
   295      1100     127892.0    116.3     15.4      return TensorMap(keys=keys, blocks=blocks)
```

This PR removed most of the Python-side overhead, and what remains comes from two main sources:

- the cost of calling a Python function from Rust/C (used to get the shape of the data in TensorBlock constructor)
- the cost of checking that all values in the "sample" dimension of the gradient sample are in-bounds, used in `add_gradient`.

I'll continue looking into these and the metatensor-torch side of things.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
