### PR TITLE
Remove Torch prefix for types in `metatensor_torch::` namespace

### DIFF
--- a/docs/src/torch/reference/cxx/block.rst
+++ b/docs/src/torch/reference/cxx/block.rst
@@ -1,7 +1,7 @@
 TensorBlock
 ===========
 
-.. doxygentypedef:: metatensor_torch::TorchTensorBlock
+.. doxygentypedef:: metatensor_torch::TensorBlock
 
 .. doxygenclass:: metatensor_torch::TensorBlockHolder
     :members:

--- a/docs/src/torch/reference/cxx/labels.rst
+++ b/docs/src/torch/reference/cxx/labels.rst
@@ -1,12 +1,12 @@
 Labels
 ======
 
-.. doxygentypedef:: metatensor_torch::TorchLabels
+.. doxygentypedef:: metatensor_torch::Labels
 
 .. doxygenclass:: metatensor_torch::LabelsHolder
     :members:
 
-.. doxygentypedef:: metatensor_torch::TorchLabelsEntry
+.. doxygentypedef:: metatensor_torch::LabelsEntry
 
 .. doxygenclass:: metatensor_torch::LabelsEntryHolder
     :members:

--- a/docs/src/torch/reference/cxx/miscellaneous.rst
+++ b/docs/src/torch/reference/cxx/miscellaneous.rst
@@ -30,9 +30,9 @@ Version number
 ``TensorMap`` Serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: metatensor_torch::save(const std::string &path, TorchTensorMap tensor)
+.. doxygenfunction:: metatensor_torch::save(const std::string &path, TensorMap tensor)
 
-.. doxygenfunction:: metatensor_torch::save_buffer(TorchTensorMap tensor)
+.. doxygenfunction:: metatensor_torch::save_buffer(TensorMap tensor)
 
 .. doxygenfunction:: metatensor_torch::load
 
@@ -43,9 +43,9 @@ Version number
 ``TensorBlock`` Serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: metatensor_torch::save(const std::string &path, TorchTensorBlock block)
+.. doxygenfunction:: metatensor_torch::save(const std::string &path, TensorBlock block)
 
-.. doxygenfunction:: metatensor_torch::save_buffer(TorchTensorBlock block)
+.. doxygenfunction:: metatensor_torch::save_buffer(TensorBlock block)
 
 .. doxygenfunction:: metatensor_torch::load_block
 
@@ -55,9 +55,9 @@ Version number
 ``Labels`` Serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. doxygenfunction:: metatensor_torch::save(const std::string &path, TorchLabels labels)
+.. doxygenfunction:: metatensor_torch::save(const std::string &path, Labels labels)
 
-.. doxygenfunction:: metatensor_torch::save_buffer(TorchLabels labels)
+.. doxygenfunction:: metatensor_torch::save_buffer(Labels labels)
 
 .. doxygenfunction:: metatensor_torch::load_labels
 

--- a/docs/src/torch/reference/cxx/tensor.rst
+++ b/docs/src/torch/reference/cxx/tensor.rst
@@ -1,7 +1,7 @@
 TensorMap
 =========
 
-.. doxygentypedef:: metatensor_torch::TorchTensorMap
+.. doxygentypedef:: metatensor_torch::TensorMap
 
 .. doxygenclass:: metatensor_torch::TensorMapHolder
     :members:

--- a/metatensor-torch/CHANGELOG.md
+++ b/metatensor-torch/CHANGELOG.md
@@ -26,6 +26,11 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `metatensor.torch.atomistic.load_system`. For the initial implementation,
   these functions are only accessible from Python.
 
+- `metatensor_torch::TorchLabels` is now `metatensor_torch::Labels`; and
+  similarly for `metatensor_torch::TensorBlock` and similarly for
+  `metatensor_torch::TensorMap`. We temporarily provide type aliases for
+  backward compatibilty.
+
 ## [Version 0.6.3](https://github.com/metatensor/metatensor/releases/tag/metatensor-torch-v0.6.3) - 2024-12-11
 
 ### Fixed

--- a/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/model.hpp
@@ -196,7 +196,7 @@ public:
     ModelEvaluationOptionsHolder(
         std::string length_unit,
         torch::Dict<std::string, ModelOutput> outputs,
-        torch::optional<TorchLabels> selected_atoms
+        torch::optional<Labels> selected_atoms
     );
 
     ~ModelEvaluationOptionsHolder() override = default;
@@ -215,12 +215,12 @@ public:
     /// to `None`, run the calculation on all atoms. If this is a set of
     /// `Labels`, it will have two dimensions named `"system"` and `"atom"`,
     /// containing the 0-based indices of all the atoms in the selected subset.
-    torch::optional<TorchLabels> get_selected_atoms() const {
+    torch::optional<Labels> get_selected_atoms() const {
         return selected_atoms_;
     }
 
     /// Setter for `selected_atoms`
-    void set_selected_atoms(torch::optional<TorchLabels> selected_atoms);
+    void set_selected_atoms(torch::optional<Labels> selected_atoms);
 
     /// Serialize a `ModelEvaluationOptions` to a JSON string.
     std::string to_json() const;
@@ -229,7 +229,7 @@ public:
 
 private:
     std::string length_unit_;
-    torch::optional<TorchLabels> selected_atoms_ = torch::nullopt;
+    torch::optional<Labels> selected_atoms_ = torch::nullopt;
 };
 
 

--- a/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
+++ b/metatensor-torch/include/metatensor/torch/atomistic/system.hpp
@@ -117,7 +117,7 @@ public:
         torch::autograd::AutogradContext* ctx,
         torch::Tensor positions,
         torch::Tensor cell,
-        TorchTensorBlock neighbors,
+        TensorBlock neighbors,
         bool check_consistency
     );
 
@@ -140,7 +140,7 @@ public:
 /// checks in case the data in neighbors does not follow what's expected.
 METATENSOR_TORCH_EXPORT void register_autograd_neighbors(
     System system,
-    TorchTensorBlock neighbors,
+    TensorBlock neighbors,
     bool check_consistency
 );
 
@@ -242,11 +242,11 @@ public:
     /// The neighbors values must contain the distance vector from the first to
     /// the second atom, i.e. `positions[second_atom] - positions[first_atom] +
     /// cell_shift_a * cell_a + cell_shift_b * cell_b + cell_shift_c * cell_c`.
-    void add_neighbor_list(NeighborListOptions options, TorchTensorBlock neighbors);
+    void add_neighbor_list(NeighborListOptions options, TensorBlock neighbors);
 
     /// Retrieve a previously stored neighbor list with the given options, or
     /// throw an error if no such neighbor list exists.
-    TorchTensorBlock get_neighbor_list(NeighborListOptions options) const;
+    TensorBlock get_neighbor_list(NeighborListOptions options) const;
 
     /// Get the options for all neighbor lists registered with this `System`
     std::vector<NeighborListOptions> known_neighbor_lists() const;
@@ -260,10 +260,10 @@ public:
     /// @param tensor the data to store
     /// @param override if true, allow this function to override existing data
     ///                 with the same name
-    void add_data(std::string name, TorchTensorMap tensor, bool override=false);
+    void add_data(std::string name, TensorMap tensor, bool override=false);
 
     /// Retrieve custom data stored in this System, or throw an error.
-    TorchTensorMap get_data(std::string name) const;
+    TensorMap get_data(std::string name) const;
 
     /// Get the list of data registered with this `System`
     std::vector<std::string> known_data() const;
@@ -292,8 +292,8 @@ private:
     torch::Tensor cell_;
     torch::Tensor pbc_;
 
-    std::map<NeighborListOptions, TorchTensorBlock, nl_options_compare> neighbors_;
-    std::unordered_map<std::string, TorchTensorMap> data_;
+    std::map<NeighborListOptions, TensorBlock, nl_options_compare> neighbors_;
+    std::unordered_map<std::string, TensorMap> data_;
 };
 
 }

--- a/metatensor-torch/include/metatensor/torch/labels.hpp
+++ b/metatensor-torch/include/metatensor/torch/labels.hpp
@@ -13,11 +13,17 @@ namespace metatensor_torch {
 
 class LabelsHolder;
 /// TorchScript will always manipulate `LabelsHolder` through a `torch::intrusive_ptr`
-using TorchLabels = torch::intrusive_ptr<LabelsHolder>;
+using Labels = torch::intrusive_ptr<LabelsHolder>;
+
+// for backward compatibility, to remove later
+using TorchLabels = Labels;
 
 class LabelsEntryHolder;
 /// TorchScript will always manipulate `LabelsEntryHolder` through a `torch::intrusive_ptr`
-using TorchLabelsEntry = torch::intrusive_ptr<LabelsEntryHolder>;
+using LabelsEntry = torch::intrusive_ptr<LabelsEntryHolder>;
+
+// for backward compatibility, to remove later
+using TorchLabelsEntry = LabelsEntry;
 
 namespace details {
     /// Transform a torch::IValue containing either a single string, a list of
@@ -29,7 +35,7 @@ namespace details {
 /// Wrapper around `metatensor::Labels` for integration with TorchScript
 ///
 /// Python/TorchScript code will typically manipulate
-/// `torch::intrusive_ptr<LabelsHolder>` (i.e. `TorchLabels`) instead of
+/// `torch::intrusive_ptr<LabelsHolder>` (i.e. `Labels`) instead of
 /// instances of `LabelsHolder`.
 ///
 /// The main difference with `metatensor::Labels` is that the values of the
@@ -47,23 +53,23 @@ public:
 
     /// Convenience constructor for building `LabelsHolder` in C++, similar to
     /// `metatensor::Labels`.
-    static TorchLabels create(
+    static Labels create(
         std::vector<std::string> names,
         const std::vector<std::initializer_list<int32_t>>& values
     );
 
     /// Get a view of `labels` corresponding to only the given columns names
-    static TorchLabels view(const TorchLabels& labels, std::vector<std::string> names);
+    static Labels view(const Labels& labels, std::vector<std::string> names);
 
     /// Create Labels with a single entry, and a single dimension named `"_"`
-    static TorchLabels single();
+    static Labels single();
 
     /// Create Labels with the given dimension names and zero entries
-    static TorchLabels empty(torch::IValue names);
+    static Labels empty(torch::IValue names);
 
     /// Create Labels with a single dimension with the given name and values in
     /// the [0, stop) range
-    static TorchLabels range(std::string name, int64_t end);
+    static Labels range(std::string name, int64_t end);
 
     /// Create a `LabelsHolder` from a pre-existing `metatensor::Labels`
     explicit LabelsHolder(metatensor::Labels labels);
@@ -80,21 +86,21 @@ public:
 
     /// Create new `Labels` with a new dimension with the given `name` and
     /// `values` added to the end of the dimensions list.
-    TorchLabels append(std::string name, torch::Tensor values) const;
+    Labels append(std::string name, torch::Tensor values) const;
 
     /// Create new `Labels` with a new dimension with the given `name` and
     /// `values` before `index`.
-    TorchLabels insert(int64_t index, std::string name, torch::Tensor values) const;
+    Labels insert(int64_t index, std::string name, torch::Tensor values) const;
 
     /// Create new `Labels` with permuted dimensions
-    TorchLabels permute(std::vector<int64_t> dimensions_indexes) const;
+    Labels permute(std::vector<int64_t> dimensions_indexes) const;
 
     /// Create new `Labels` with `name` removed from the dimensions list
-    TorchLabels remove(std::string name) const;
+    Labels remove(std::string name) const;
 
     /// Create new `Labels` with `old_name` renamed to `new_name` in the
     /// dimensions list
-    TorchLabels rename(std::string old_name, std::string new_name) const;
+    Labels rename(std::string old_name, std::string new_name) const;
 
     /// Get the current device for these `Labels`
     torch::Device device() const {
@@ -102,10 +108,10 @@ public:
     }
 
     /// Move the values for these Labels to the given `device`
-    TorchLabels to(torch::IValue device) const;
+    Labels to(torch::IValue device) const;
 
     /// Move the values for these Labels to the given `device`
-    TorchLabels to(torch::Device device) const;
+    Labels to(torch::Device device) const;
 
     /// Get the values associated with a single dimension (i.e. a single column
     /// of `values()`) in these labels.
@@ -161,23 +167,23 @@ public:
     // A view is created by the `view` function (also `__getitem__` in Python),
     // and does not have a corresponding `metatensor::Labels` (`labels_` is
     // `nullopt`)
-    TorchLabels to_owned() const;
+    Labels to_owned() const;
 
     /// Get the union of `this` and `other`
-    TorchLabels set_union(const TorchLabels& other) const;
+    Labels set_union(const Labels& other) const;
 
     /// Get the union of `this` and `other`, as well as the mapping from
     /// positions of entries in the input to the position of entries in the
     /// output.
-    std::tuple<TorchLabels, torch::Tensor, torch::Tensor> union_and_mapping(const TorchLabels& other) const;
+    std::tuple<Labels, torch::Tensor, torch::Tensor> union_and_mapping(const Labels& other) const;
 
     /// Get the intersection of `this` and `other`
-    TorchLabels set_intersection(const TorchLabels& other) const;
+    Labels set_intersection(const Labels& other) const;
 
     /// Get the intersection of `this` and `other`, as well as the mapping from
     /// positions of entries in the input to the position of entries in the
     /// output.
-    std::tuple<TorchLabels, torch::Tensor, torch::Tensor> intersection_and_mapping(const TorchLabels& other) const;
+    std::tuple<Labels, torch::Tensor, torch::Tensor> intersection_and_mapping(const Labels& other) const;
 
     /// Select entries in these `Labels` that match the `selection`.
     ///
@@ -186,14 +192,14 @@ public:
     /// All entries in these `Labels` that match one of the entry in the
     /// `selection` for all the selection's dimension will be picked. Any entry
     /// in the `selection` but not in these `Labels` will be ignored.
-    torch::Tensor select(const TorchLabels& selection) const;
+    torch::Tensor select(const Labels& selection) const;
 
     /// Load serialized Labels from the given path
-    static TorchLabels load(const std::string& path);
+    static Labels load(const std::string& path);
 
     /// Load serialized Labels from an in-memory buffer (represented as a
     /// `torch::Tensor` of bytes)
-    static TorchLabels load_buffer(torch::Tensor buffer);
+    static Labels load_buffer(torch::Tensor buffer);
 
     /// Serialize and save Labels to the given path
     void save(const std::string& path) const;
@@ -258,12 +264,12 @@ inline bool operator!=(const metatensor::Labels& lhs, const LabelsHolder& rhs) {
 }
 
 
-/// A single entry inside a `TorchLabels`
+/// A single entry inside a `Labels`
 class METATENSOR_TORCH_EXPORT LabelsEntryHolder: public torch::CustomClassHolder {
 public:
     /// Create a new `LabelsEntryHolder` corresponding to the entry at the given
     /// `index` in the given `labels`
-    LabelsEntryHolder(TorchLabels labels, int64_t index);
+    LabelsEntryHolder(Labels labels, int64_t index);
 
     /// Get the names of the dimensions/columns of these Labels
     std::vector<std::string> names() const {
@@ -307,7 +313,7 @@ public:
 private:
     torch::Tensor values_;
 
-    TorchLabels labels_;
+    Labels labels_;
 };
 
 

--- a/metatensor-torch/include/metatensor/torch/misc.hpp
+++ b/metatensor-torch/include/metatensor/torch/misc.hpp
@@ -24,50 +24,50 @@ namespace details {
 }
 
 /// Load a previously saved `TensorMap` from the given path.
-METATENSOR_TORCH_EXPORT TorchTensorMap load(const std::string& path);
+METATENSOR_TORCH_EXPORT TensorMap load(const std::string& path);
 
 /// Load a previously saved `TensorMap` from the given in-memory buffer
 /// (represented as a `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT TorchTensorMap load_buffer(torch::Tensor buffer);
+METATENSOR_TORCH_EXPORT TensorMap load_buffer(torch::Tensor buffer);
 
 /// Save the given `TensorMap` to a file at `path`
-METATENSOR_TORCH_EXPORT void save(const std::string& path, TorchTensorMap tensor);
+METATENSOR_TORCH_EXPORT void save(const std::string& path, TensorMap tensor);
 
 /// Save the given `TensorMap` to an in-memory buffer (represented as a
 /// `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(TorchTensorMap tensor);
+METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(TensorMap tensor);
 
 /******************************************************************************/
 
 /// Load a previously saved `TensorBlock` from the given path.
-METATENSOR_TORCH_EXPORT TorchTensorBlock load_block(const std::string& path);
+METATENSOR_TORCH_EXPORT TensorBlock load_block(const std::string& path);
 
 /// Load a previously saved `TensorBlock` from the given in-memory buffer
 /// (represented as a `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT TorchTensorBlock load_block_buffer(torch::Tensor buffer);
+METATENSOR_TORCH_EXPORT TensorBlock load_block_buffer(torch::Tensor buffer);
 
 /// Save the given `TensorBlock` to a file at `path`
-METATENSOR_TORCH_EXPORT void save(const std::string& path, TorchTensorBlock block);
+METATENSOR_TORCH_EXPORT void save(const std::string& path, TensorBlock block);
 
 /// Save the given `TensorBlock` to an in-memory buffer (represented as a
 /// `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(TorchTensorBlock block);
+METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(TensorBlock block);
 
 /******************************************************************************/
 
 /// Load previously saved `Labels` from the given path.
-METATENSOR_TORCH_EXPORT TorchLabels load_labels(const std::string& path);
+METATENSOR_TORCH_EXPORT Labels load_labels(const std::string& path);
 
 /// Load previously saved `Labels` from the given in-memory buffer
 /// (represented as a `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT TorchLabels load_labels_buffer(torch::Tensor buffer);
+METATENSOR_TORCH_EXPORT Labels load_labels_buffer(torch::Tensor buffer);
 
 /// Save the given `Labels` to a file at `path`
-METATENSOR_TORCH_EXPORT void save(const std::string& path, TorchLabels labels);
+METATENSOR_TORCH_EXPORT void save(const std::string& path, Labels labels);
 
 /// Save the given `Labels` to an in-memory buffer (represented as a
 /// `torch::Tensor` of bytes)
-METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(TorchLabels labels);
+METATENSOR_TORCH_EXPORT torch::Tensor save_buffer(Labels labels);
 
 }
 

--- a/metatensor-torch/include/metatensor/torch/tensor.hpp
+++ b/metatensor-torch/include/metatensor/torch/tensor.hpp
@@ -15,12 +15,15 @@ namespace metatensor_torch {
 
 class TensorMapHolder;
 /// TorchScript will always manipulate `TensorMapHolder` through a `torch::intrusive_ptr`
-using TorchTensorMap = torch::intrusive_ptr<TensorMapHolder>;
+using TensorMap = torch::intrusive_ptr<TensorMapHolder>;
+
+// for backward compatibility, to remove later
+using TorchTensorMap = TensorMap;
 
 /// Wrapper around `metatensor::TensorMap` for integration with TorchScript
 ///
 /// Python/TorchScript code will typically manipulate
-/// `torch::intrusive_ptr<TensorMapHolder>` (i.e. `TorchTensorMap`) instead
+/// `torch::intrusive_ptr<TensorMapHolder>` (i.e. `TensorMap`) instead
 /// of instances of `TensorMapHolder`.
 class METATENSOR_TORCH_EXPORT TensorMapHolder: public torch::CustomClassHolder {
 public:
@@ -30,60 +33,60 @@ public:
     /// different blocks, but instead create new ones using the same data and
     /// metadata, but with incremented reference count.
     TensorMapHolder(
-        TorchLabels keys,
-        const std::vector<TorchTensorBlock>& blocks
+        Labels keys,
+        const std::vector<TensorBlock>& blocks
     );
 
     /// Make a copy of this `TensorMap`, including all the data contained inside
-    TorchTensorMap copy() const;
+    TensorMap copy() const;
 
     /// Get the keys for this `TensorMap`
-    TorchLabels keys() const;
+    Labels keys() const;
 
     /// Get a (possibly empty) list of block indexes matching the `selection`
-    std::vector<int64_t> blocks_matching(const TorchLabels& selection) const;
+    std::vector<int64_t> blocks_matching(const Labels& selection) const;
 
     /// Get a block inside this TensorMap by it's index/the index of the
     /// corresponding key.
     ///
     /// The returned `TensorBlock` is a view inside memory owned by this
     /// `TensorMap`, and is only valid as long as the `TensorMap` is kept alive.
-    static TorchTensorBlock block_by_id(TorchTensorMap self, int64_t index);
+    static TensorBlock block_by_id(TensorMap self, int64_t index);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`
-    static TorchTensorBlock block(TorchTensorMap self, const std::map<std::string, int32_t>& selection);
+    static TensorBlock block(TensorMap self, const std::map<std::string, int32_t>& selection);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`. The `selection` must contain a single entry.
-    static TorchTensorBlock block(TorchTensorMap self, TorchLabels selection);
+    static TensorBlock block(TensorMap self, Labels selection);
 
     /// Get the block in this `TensorMap` with the key matching the name=>values
     /// passed in `selection`
-    static TorchTensorBlock block(TorchTensorMap self, TorchLabelsEntry selection);
+    static TensorBlock block(TensorMap self, LabelsEntry selection);
 
     /// TorchScript implementation of `block`, dispatching to one of the
     /// functions above
-    static TorchTensorBlock block_torch(TorchTensorMap self, torch::IValue index);
+    static TensorBlock block_torch(TensorMap self, torch::IValue index);
 
     /// Similar to `block_by_id`, but get all blocks with the given indices
-    static std::vector<TorchTensorBlock> blocks_by_id(TorchTensorMap self, const std::vector<int64_t>& indices);
+    static std::vector<TensorBlock> blocks_by_id(TensorMap self, const std::vector<int64_t>& indices);
 
     /// Get all blocks in this TensorMap
-    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self);
+    static std::vector<TensorBlock> blocks(TensorMap self);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, const std::map<std::string, int32_t>& selection);
+    static std::vector<TensorBlock> blocks(TensorMap self, const std::map<std::string, int32_t>& selection);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, TorchLabels selection);
+    static std::vector<TensorBlock> blocks(TensorMap self, Labels selection);
 
     /// Similar to `block`, but allow getting multiple matching blocks
-    static std::vector<TorchTensorBlock> blocks(TorchTensorMap self, TorchLabelsEntry selection);
+    static std::vector<TensorBlock> blocks(TensorMap self, LabelsEntry selection);
 
     /// TorchScript implementation of `blocks`, dispatching to one of the
     /// functions above.
-    static std::vector<TorchTensorBlock> blocks_torch(TorchTensorMap self, torch::IValue index);
+    static std::vector<TensorBlock> blocks_torch(TensorMap self, torch::IValue index);
 
     /// Merge blocks with the same value for selected keys dimensions along the
     /// property axis.
@@ -92,8 +95,8 @@ public:
     /// this function.
     ///
     /// The input `torch::IValue` can be a single string, a list/tuple of
-    /// strings, or a `TorchLabels` instance.
-    TorchTensorMap keys_to_properties(torch::IValue keys_to_move, bool sort_samples) const;
+    /// strings, or a `Labels` instance.
+    TensorMap keys_to_properties(torch::IValue keys_to_move, bool sort_samples) const;
 
     /// Merge blocks with the same value for selected keys dimensions along the
     /// sample axis.
@@ -102,8 +105,8 @@ public:
     /// this function.
     ///
     /// The input `torch::IValue` can be a single string, a list/tuple of
-    /// strings, or a `TorchLabels` instance.
-    TorchTensorMap keys_to_samples(torch::IValue keys_to_move, bool sort_samples) const;
+    /// strings, or a `Labels` instance.
+    TensorMap keys_to_samples(torch::IValue keys_to_move, bool sort_samples) const;
 
     /// Move the given `dimensions` from the component labels to the property
     /// labels for each block.
@@ -113,7 +116,7 @@ public:
     ///
     /// The input `torch::IValue` can be a single string, or a list/tuple of
     /// strings.
-    TorchTensorMap components_to_properties(torch::IValue dimensions) const;
+    TensorMap components_to_properties(torch::IValue dimensions) const;
 
     /// Get the names of the samples dimensions for all blocks in this
     /// `TensorMap`
@@ -128,7 +131,7 @@ public:
     std::vector<std::string> property_names();
 
     /// Get all (key => block) pairs in this `TensorMap`
-    static std::vector<std::tuple<TorchLabelsEntry, TorchTensorBlock>> items(TorchTensorMap self);
+    static std::vector<std::tuple<LabelsEntry, TensorBlock>> items(TensorMap self);
 
     /// Print this TensorMap to a string, including at most `max_keys` in the
     /// output (-1 to include all keys).
@@ -141,7 +144,7 @@ public:
     torch::Dtype scalar_type() const;
 
     /// Move this `TensorMap` to the given `dtype` and `device`.
-    TorchTensorMap to(
+    TensorMap to(
         torch::optional<torch::Dtype> dtype = torch::nullopt,
         torch::optional<torch::Device> device = torch::nullopt
     ) const;
@@ -154,7 +157,7 @@ public:
     /// `arrays` is left as a keyword argument since it is mainly here for
     /// compatibility with the pure Python backend, and only `"torch"` is
     /// supported.
-    TorchTensorMap to_positional(
+    TensorMap to_positional(
         torch::IValue positional_1,
         torch::IValue positional_2,
         torch::optional<torch::Dtype> dtype,
@@ -168,11 +171,11 @@ public:
     }
 
     /// Load a serialized TensorMap from the given path
-    static TorchTensorMap load(const std::string& path);
+    static TensorMap load(const std::string& path);
 
     /// Load a serialized TensorMap from an in-memory buffer (represented as a
     /// `torch::Tensor` of bytes)
-    static TorchTensorMap load_buffer(torch::Tensor buffer);
+    static TensorMap load_buffer(torch::Tensor buffer);
 
     /// Serialize and save a TensorMap to the given path
     void save(const std::string& path) const;

--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -283,7 +283,7 @@ ModelCapabilities ModelCapabilitiesHolder::from_json(std::string_view json) {
 
 /******************************************************************************/
 
-static void check_selected_atoms(const torch::optional<TorchLabels>& selected_atoms) {
+static void check_selected_atoms(const torch::optional<Labels>& selected_atoms) {
     if (selected_atoms) {
         if (selected_atoms.value()->names() != std::vector<std::string>{"system", "atom"}) {
             std::ostringstream oss;
@@ -309,7 +309,7 @@ void ModelEvaluationOptionsHolder::set_length_unit(std::string unit) {
 ModelEvaluationOptionsHolder::ModelEvaluationOptionsHolder(
     std::string length_unit_,
     torch::Dict<std::string, ModelOutput> outputs_,
-    torch::optional<TorchLabels> selected_atoms
+    torch::optional<Labels> selected_atoms
 ):
     outputs(outputs_),
     selected_atoms_(std::move(selected_atoms))
@@ -319,7 +319,7 @@ ModelEvaluationOptionsHolder::ModelEvaluationOptionsHolder(
 }
 
 
-void ModelEvaluationOptionsHolder::set_selected_atoms(torch::optional<TorchLabels> selected_atoms) {
+void ModelEvaluationOptionsHolder::set_selected_atoms(torch::optional<Labels> selected_atoms) {
     check_selected_atoms(selected_atoms);
     selected_atoms_ = std::move(selected_atoms);
 }

--- a/metatensor-torch/src/atomistic/system.cpp
+++ b/metatensor-torch/src/atomistic/system.cpp
@@ -165,7 +165,7 @@ torch::Tensor NeighborsAutograd::forward(
     torch::autograd::AutogradContext* ctx,
     torch::Tensor positions,
     torch::Tensor cell,
-    TorchTensorBlock neighbors,
+    TensorBlock neighbors,
     bool check_consistency
 ) {
     auto distances = neighbors->values();
@@ -290,7 +290,7 @@ std::vector<torch::Tensor> NeighborsAutograd::backward(
 
 void metatensor_torch::register_autograd_neighbors(
     System system,
-    TorchTensorBlock neighbors,
+    TensorBlock neighbors,
     bool check_consistency
 ) {
     auto distances = neighbors->values();
@@ -689,7 +689,7 @@ System SystemHolder::to_positional(
 }
 
 
-void SystemHolder::add_neighbor_list(NeighborListOptions options, TorchTensorBlock neighbors) {
+void SystemHolder::add_neighbor_list(NeighborListOptions options, TensorBlock neighbors) {
     // check the structure of the NL
     auto samples_names = neighbors->samples()->names();
     if (samples_names.size() != 5 ||
@@ -757,7 +757,7 @@ void SystemHolder::add_neighbor_list(NeighborListOptions options, TorchTensorBlo
     neighbors_.emplace(std::move(options), std::move(neighbors));
 }
 
-TorchTensorBlock SystemHolder::get_neighbor_list(NeighborListOptions options) const {
+TensorBlock SystemHolder::get_neighbor_list(NeighborListOptions options) const {
     auto it = neighbors_.find(options);
     if (it == neighbors_.end()) {
         C10_THROW_ERROR(ValueError,
@@ -810,7 +810,7 @@ static auto INVALID_DATA_NAMES = std::unordered_set<std::string>{
     "neighbors", "neighbor"
 };
 
-void SystemHolder::add_data(std::string name, TorchTensorMap tensor, bool override) {
+void SystemHolder::add_data(std::string name, TensorMap tensor, bool override) {
     if (!valid_ident(name)) {
         C10_THROW_ERROR(ValueError,
             "custom data name '" + name + "' is invalid: only [a-z A-Z 0-9 _-] are accepted"
@@ -847,7 +847,7 @@ void SystemHolder::add_data(std::string name, TorchTensorMap tensor, bool overri
     data_.insert_or_assign(std::move(name), std::move(tensor));
 }
 
-TorchTensorMap SystemHolder::get_data(std::string name) const {
+TensorMap SystemHolder::get_data(std::string name) const {
     if (INVALID_DATA_NAMES.find(string_lower(name)) != INVALID_DATA_NAMES.end()) {
         C10_THROW_ERROR(ValueError,
             "custom data can not be named '" + name + "'"

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -139,7 +139,7 @@ LabelsHolder::LabelsHolder(torch::IValue names, torch::Tensor values):
     labels_->set_user_data(std::move(user_data));
 }
 
-TorchLabels LabelsHolder::create(
+Labels LabelsHolder::create(
     std::vector<std::string> names,
     const std::vector<std::initializer_list<int32_t>>& values
 ) {
@@ -154,7 +154,7 @@ LabelsHolder::LabelsHolder(std::vector<std::string> names, torch::Tensor values,
     labels_(torch::nullopt)
 {}
 
-TorchLabels LabelsHolder::view(const TorchLabels& labels, std::vector<std::string> names) {
+Labels LabelsHolder::view(const Labels& labels, std::vector<std::string> names) {
     if (names.empty()) {
         C10_THROW_ERROR(ValueError,
             "can not index Labels with an empty list of dimension names"
@@ -221,14 +221,14 @@ LabelsHolder::LabelsHolder(metatensor::Labels labels): labels_(std::move(labels)
 }
 
 
-TorchLabels LabelsHolder::single() {
+Labels LabelsHolder::single() {
     auto options = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
     auto values = torch::tensor({0}, options).reshape({1, 1});
     return torch::make_intrusive<LabelsHolder>("_", std::move(values));
 }
 
 
-TorchLabels LabelsHolder::empty(torch::IValue names_ivalue) {
+Labels LabelsHolder::empty(torch::IValue names_ivalue) {
     auto names = details::normalize_names(names_ivalue, "empty");
     auto options = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
     auto values = torch::tensor(std::vector<int>(), options).reshape({0, static_cast<int64_t>(names.size())});
@@ -236,7 +236,7 @@ TorchLabels LabelsHolder::empty(torch::IValue names_ivalue) {
 }
 
 
-TorchLabels LabelsHolder::range(std::string name, int64_t end) {
+Labels LabelsHolder::range(std::string name, int64_t end) {
     auto options = torch::TensorOptions().dtype(torch::kInt32).device(torch::kCPU);
     auto values = torch::arange(end, options).reshape({end, 1});
     return torch::make_intrusive<LabelsHolder>(name, std::move(values));
@@ -265,7 +265,7 @@ const metatensor::Labels& LabelsHolder::as_metatensor() const {
     return labels_.value();
 }
 
-TorchLabels LabelsHolder::to_owned() const {
+Labels LabelsHolder::to_owned() const {
     if (labels_.has_value()) {
         return torch::make_intrusive<LabelsHolder>(*this);
     } else {
@@ -273,12 +273,12 @@ TorchLabels LabelsHolder::to_owned() const {
     }
 }
 
-TorchLabels LabelsHolder::append(std::string name, torch::Tensor values) const {
+Labels LabelsHolder::append(std::string name, torch::Tensor values) const {
     return this->insert(this->size(), std::move(name), std::move(values));
 }
 
 
-TorchLabels LabelsHolder::insert(int64_t index, std::string name, torch::Tensor values) const {
+Labels LabelsHolder::insert(int64_t index, std::string name, torch::Tensor values) const {
     auto new_names = this->names();
 
     auto it = std::begin(new_names) + index;
@@ -309,7 +309,7 @@ TorchLabels LabelsHolder::insert(int64_t index, std::string name, torch::Tensor 
 }
 
 
-TorchLabels LabelsHolder::permute(std::vector<int64_t> dimensions_indexes) const {
+Labels LabelsHolder::permute(std::vector<int64_t> dimensions_indexes) const {
     auto names = this->names();
 
     if (dimensions_indexes.size() != names.size()) {
@@ -342,7 +342,7 @@ TorchLabels LabelsHolder::permute(std::vector<int64_t> dimensions_indexes) const
 }
 
 
-TorchLabels LabelsHolder::remove(std::string name) const {
+Labels LabelsHolder::remove(std::string name) const {
     auto new_names = this->names();
 
     auto it = std::find(std::begin(new_names), std::end(new_names), name);
@@ -365,7 +365,7 @@ TorchLabels LabelsHolder::remove(std::string name) const {
 }
 
 
-TorchLabels LabelsHolder::rename(std::string old_name, std::string new_name) const {
+Labels LabelsHolder::rename(std::string old_name, std::string new_name) const {
     auto new_names = this->names();
 
     auto it = std::find(std::begin(new_names), std::end(new_names), old_name);
@@ -381,7 +381,7 @@ TorchLabels LabelsHolder::rename(std::string old_name, std::string new_name) con
     return torch::make_intrusive<LabelsHolder>(std::move(new_names), this->values());
 }
 
-TorchLabels LabelsHolder::to(torch::IValue device_ivalue) const {
+Labels LabelsHolder::to(torch::IValue device_ivalue) const {
     auto device = this->device();
     if (device_ivalue.isNone()) {
         // nothing to do
@@ -397,7 +397,7 @@ TorchLabels LabelsHolder::to(torch::IValue device_ivalue) const {
     return this->to(device);
 }
 
-TorchLabels LabelsHolder::to(torch::Device device) const {
+Labels LabelsHolder::to(torch::Device device) const {
     if (device == values_.device()) {
         // return the same object
         return torch::make_intrusive<LabelsHolder>(*this);
@@ -490,7 +490,7 @@ torch::optional<int64_t> LabelsHolder::position(torch::IValue entry) const {
     }
 }
 
-TorchLabels LabelsHolder::set_union(const TorchLabels& other) const {
+Labels LabelsHolder::set_union(const Labels& other) const {
     if (!labels_.has_value() || !other->labels_.has_value()) {
         C10_THROW_ERROR(ValueError,
             "can not call this function on Labels view, call to_owned first"
@@ -509,7 +509,7 @@ TorchLabels LabelsHolder::set_union(const TorchLabels& other) const {
     return result.to(device);
 }
 
-std::tuple<TorchLabels, torch::Tensor, torch::Tensor> LabelsHolder::union_and_mapping(const TorchLabels& other) const {
+std::tuple<Labels, torch::Tensor, torch::Tensor> LabelsHolder::union_and_mapping(const Labels& other) const {
     if (!labels_.has_value() || !other->labels_.has_value()) {
         C10_THROW_ERROR(ValueError,
             "can not call this function on Labels view, call to_owned first"
@@ -536,14 +536,14 @@ std::tuple<TorchLabels, torch::Tensor, torch::Tensor> LabelsHolder::union_and_ma
         second_mapping.size(0)
     ));
 
-    return std::make_tuple<TorchLabels, torch::Tensor, torch::Tensor>(
+    return std::make_tuple<Labels, torch::Tensor, torch::Tensor>(
         result.to(device),
         first_mapping.to(device),
         second_mapping.to(device)
     );
 }
 
-TorchLabels LabelsHolder::set_intersection(const TorchLabels& other) const {
+Labels LabelsHolder::set_intersection(const Labels& other) const {
     if (!labels_.has_value() || !other->labels_.has_value()) {
         C10_THROW_ERROR(ValueError,
             "can not call this function on Labels view, call to_owned first"
@@ -562,7 +562,7 @@ TorchLabels LabelsHolder::set_intersection(const TorchLabels& other) const {
     return result.to(device);
 }
 
-std::tuple<TorchLabels, torch::Tensor, torch::Tensor> LabelsHolder::intersection_and_mapping(const TorchLabels& other) const {
+std::tuple<Labels, torch::Tensor, torch::Tensor> LabelsHolder::intersection_and_mapping(const Labels& other) const {
     if (!labels_.has_value() || !other->labels_.has_value()) {
         C10_THROW_ERROR(ValueError,
             "can not call this function on Labels view, call to_owned first"
@@ -589,14 +589,14 @@ std::tuple<TorchLabels, torch::Tensor, torch::Tensor> LabelsHolder::intersection
         second_mapping.size(0)
     ));
 
-    return std::make_tuple<TorchLabels, torch::Tensor, torch::Tensor>(
+    return std::make_tuple<Labels, torch::Tensor, torch::Tensor>(
         result.to(device),
         first_mapping.to(device),
         second_mapping.to(device)
     );
 }
 
-torch::Tensor LabelsHolder::select(const TorchLabels& selection) const {
+torch::Tensor LabelsHolder::select(const Labels& selection) const {
     if (!labels_.has_value() || !selection->labels_.has_value()) {
         C10_THROW_ERROR(ValueError,
             "can not call this function on Labels view, call to_owned first"
@@ -799,14 +799,14 @@ std::string LabelsHolder::repr() const {
 }
 
 
-TorchLabels LabelsHolder::load(const std::string& path) {
+Labels LabelsHolder::load(const std::string& path) {
     return torch::make_intrusive<LabelsHolder>(
         LabelsHolder(metatensor::io::load_labels(path))
     );
 }
 
 
-TorchLabels LabelsHolder::load_buffer(torch::Tensor buffer) {
+Labels LabelsHolder::load_buffer(torch::Tensor buffer) {
     if (buffer.scalar_type() != torch::kUInt8) {
         C10_THROW_ERROR(ValueError,
             "`buffer` must be a tensor of uint8, not " +
@@ -857,7 +857,7 @@ torch::Tensor LabelsHolder::save_buffer() const {
 
 /******************************************************************************/
 
-LabelsEntryHolder::LabelsEntryHolder(TorchLabels labels, int64_t index):
+LabelsEntryHolder::LabelsEntryHolder(Labels labels, int64_t index):
     labels_(std::move(labels))
 {
     auto size = labels_->values().size(0);

--- a/metatensor-torch/src/misc.cpp
+++ b/metatensor-torch/src/misc.cpp
@@ -40,56 +40,56 @@ mts_status_t metatensor_torch::details::create_torch_array(
 
 /******************************************************************************/
 
-TorchTensorMap metatensor_torch::load(const std::string& path) {
+TensorMap metatensor_torch::load(const std::string& path) {
     return TensorMapHolder::load(path);
 }
 
-TorchTensorMap metatensor_torch::load_buffer(torch::Tensor buffer) {
+TensorMap metatensor_torch::load_buffer(torch::Tensor buffer) {
     return TensorMapHolder::load_buffer(buffer);
 }
 
 
-void metatensor_torch::save(const std::string& path, TorchTensorMap tensor) {
+void metatensor_torch::save(const std::string& path, TensorMap tensor) {
     tensor->save(path);
 }
 
-torch::Tensor metatensor_torch::save_buffer(TorchTensorMap tensor) {
+torch::Tensor metatensor_torch::save_buffer(TensorMap tensor) {
     return tensor->save_buffer();
 }
 
 /******************************************************************************/
 
-TorchTensorBlock metatensor_torch::load_block(const std::string& path) {
+TensorBlock metatensor_torch::load_block(const std::string& path) {
     return TensorBlockHolder::load(path);
 }
 
-TorchTensorBlock metatensor_torch::load_block_buffer(torch::Tensor buffer) {
+TensorBlock metatensor_torch::load_block_buffer(torch::Tensor buffer) {
     return TensorBlockHolder::load_buffer(buffer);
 }
 
 
-void metatensor_torch::save(const std::string& path, TorchTensorBlock block) {
+void metatensor_torch::save(const std::string& path, TensorBlock block) {
     block->save(path);
 }
 
-torch::Tensor metatensor_torch::save_buffer(TorchTensorBlock block) {
+torch::Tensor metatensor_torch::save_buffer(TensorBlock block) {
     return block->save_buffer();
 }
 
 /******************************************************************************/
 
-TorchLabels metatensor_torch::load_labels(const std::string& path) {
+Labels metatensor_torch::load_labels(const std::string& path) {
     return LabelsHolder::load(path);
 }
 
-TorchLabels metatensor_torch::load_labels_buffer(torch::Tensor buffer) {
+Labels metatensor_torch::load_labels_buffer(torch::Tensor buffer) {
     return LabelsHolder::load_buffer(buffer);
 }
 
-void metatensor_torch::save(const std::string& path, TorchLabels labels) {
+void metatensor_torch::save(const std::string& path, Labels labels) {
     labels->save(path);
 }
 
-torch::Tensor metatensor_torch::save_buffer(TorchLabels labels) {
+torch::Tensor metatensor_torch::save_buffer(Labels labels) {
     return labels->save_buffer();
 }

--- a/metatensor-torch/tests/block.cpp
+++ b/metatensor-torch/tests/block.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Blocks") {
         auto block = torch::make_intrusive<TensorBlockHolder>(
             torch::full({3, 2}, 11.0),
             LabelsHolder::create({"s"}, {{0}, {2}, {1}}),
-            std::vector<TorchLabels>{},
+            std::vector<Labels>{},
             LabelsHolder::create({"p"}, {{0}, {1}})
         );
 
@@ -58,7 +58,7 @@ TEST_CASE("Blocks") {
         block->add_gradient("g", torch::make_intrusive<TensorBlockHolder>(
             torch::full({1, 3, 2}, 1.0),
             LabelsHolder::create({"sample", "g"}, {{0, 1}}),
-            std::vector<TorchLabels>{LabelsHolder::create({"c"}, {{0}, {1}, {2}})},
+            std::vector<Labels>{LabelsHolder::create({"c"}, {{0}, {1}, {2}})},
             block->properties()
         ));
 
@@ -84,7 +84,7 @@ TEST_CASE("Blocks") {
             TensorBlockHolder(
                 torch::full({3, 2}, 11.0),
                 LabelsHolder::create({"s"}, {{0}, {2}, {1}})->to(torch::kMeta),
-                std::vector<TorchLabels>{},
+                std::vector<Labels>{},
                 LabelsHolder::create({"p"}, {{0}, {1}})
             ),
             Catch::StartsWith(

--- a/metatensor-torch/tests/tensor.cpp
+++ b/metatensor-torch/tests/tensor.cpp
@@ -6,7 +6,7 @@ using namespace metatensor_torch;
 
 #include <catch.hpp>
 
-static TorchTensorMap test_tensor_map();
+static TensorMap test_tensor_map();
 
 TEST_CASE("TensorMap") {
     SECTION("keys") {
@@ -207,10 +207,10 @@ TEST_CASE("TensorMap serialization") {
 }
 
 
-TorchTensorMap test_tensor_map() {
-    auto blocks = std::vector<TorchTensorBlock>();
+TensorMap test_tensor_map() {
+    auto blocks = std::vector<TensorBlock>();
 
-    auto components = std::vector<TorchLabels>();
+    auto components = std::vector<Labels>();
     components.emplace_back(LabelsHolder::create({"component"}, {{0}}));
 
     auto block_1 = torch::make_intrusive<TensorBlockHolder>(
@@ -245,7 +245,7 @@ TorchTensorMap test_tensor_map() {
 
     blocks.emplace_back(std::move(block_2));
 
-    components = std::vector<TorchLabels>();
+    components = std::vector<Labels>();
     components.emplace_back(LabelsHolder::create({"component"}, {{0}, {1}, {2}}));
     auto block_3 = torch::make_intrusive<TensorBlockHolder>(
         torch::full({4, 3, 1}, 3.0),


### PR DESCRIPTION
If users need to differentiate between these and the ones in `metatensor::` namespace, they should use the namespace explicitly



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2446377848.zip)

<!-- download-section Documentation docs end -->