### PR TITLE
Use bdist_wheel from setuptools, the one in wheel is deprecated

### DIFF
--- a/python/metatensor_core/pyproject.toml
+++ b/python/metatensor_core/pyproject.toml
@@ -36,9 +36,8 @@ changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=68",
+    "setuptools >=75",
     "packaging >=23",
-    "wheel >=0.41",
     "cmake",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/metatensor_core/setup.py
+++ b/python/metatensor_core/setup.py
@@ -6,9 +6,9 @@ import sys
 import packaging.version
 from setuptools import Extension, setup
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
-from wheel.bdist_wheel import bdist_wheel
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))

--- a/python/metatensor_torch/pyproject.toml
+++ b/python/metatensor_torch/pyproject.toml
@@ -34,9 +34,8 @@ changelog = "https://docs.metatensor.org/latest/torch/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=68",
+    "setuptools >=75",
     "packaging >=23",
-    "wheel >=0.41",
     "cmake",
 ]
 

--- a/python/metatensor_torch/setup.py
+++ b/python/metatensor_torch/setup.py
@@ -6,9 +6,9 @@ import sys
 import packaging.version
 from setuptools import Extension, setup
 from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_ext import build_ext
 from setuptools.command.sdist import sdist
-from wheel.bdist_wheel import bdist_wheel
 
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
@@ -258,11 +258,11 @@ if __name__ == "__main__":
         # except only applying when importing torch from a build-isolation virtual
         # environment created by pip (`python -m build` does not seems to suffer from
         # this).
-        import wheel
+        import packaging
 
         pip_virtualenv = os.path.realpath(
             os.path.join(
-                os.path.dirname(wheel.__file__),
+                os.path.dirname(packaging.__file__),
                 "..",
                 "..",
                 "..",


### PR DESCRIPTION
Building the code gave this warning:

```
          ********************************************************************************
          Ensure that any custom bdist_wheel implementation is a subclass of
          setuptools.command.bdist_wheel.bdist_wheel.

          By 2025-Oct-15, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://github.com/pypa/wheel/pull/631 for details.
          ********************************************************************************
```

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
