### PR TITLE
Build linux-arm wheels on native ARM runners

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             cibw-arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             rust-target: aarch64-unknown-linux-gnu
             cibw-arch: aarch64
           - name: x86_64 macOS
@@ -71,12 +71,8 @@ jobs:
       - name: install dependencies
         run: python -m pip install cibuildwheel twine
 
-      - name: Set up QEMU for docker
-        if: matrix.os == 'ubuntu-22.04'
-        uses: docker/setup-qemu-action@v3
-
       - name: build manylinux with rust docker image
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
         run: docker build -t rustc-manylinux2014_${{ matrix.cibw-arch }} python/scripts/rustc-manylinux2014_${{ matrix.cibw-arch }}
 
       - name: build metatensor-core wheel
@@ -107,13 +103,14 @@ jobs:
       matrix:
         torch-version: ['1.12', '1.13', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5']
         arch: ['arm64', 'x86_64']
-        os: ['ubuntu-22.04', 'macos-13', 'macos-14', 'windows-2022']
+        os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-14', 'windows-2022']
         exclude:
-          # remove mismatched arch for macOS
-          - {os: macos-14, arch: x86_64}
+          # remove mismatched arch-os combinations
           - {os: macos-13, arch: arm64}
-          # no arm64-windows build
           - {os: windows-2022, arch: arm64}
+          - {os: ubuntu-22.04, arch: arm64}
+          - {os: macos-14, arch: x86_64}
+          - {os: ubuntu-22.04-arm, arch: x86_64}
           # arch arm64 on macos is only supported for torch >= 2.0
           - {os: macos-14, arch: arm64, torch-version: '1.12'}
           - {os: macos-14, arch: arm64, torch-version: '1.13'}
@@ -129,7 +126,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             cibw-arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             arch: arm64
             rust-target: aarch64-unknown-linux-gnu
             cibw-arch: aarch64
@@ -176,12 +173,8 @@ jobs:
       - name: install dependencies
         run: python -m pip install cibuildwheel
 
-      - name: Set up QEMU for docker
-        if: matrix.os == 'ubuntu-22.04'
-        uses: docker/setup-qemu-action@v3
-
       - name: build manylinux with rust docker image
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
         run: docker buildx build -t rustc-manylinux2014_${{ matrix.cibw-arch }} python/scripts/rustc-manylinux2014_${{ matrix.cibw-arch }}
 
       - name: build metatensor-torch wheel
@@ -228,7 +221,7 @@ jobs:
             os: ubuntu-22.04
             arch: x86_64
           - name: arm64 Linux
-            os: ubuntu-22.04
+            os: ubuntu-22.04-arm
             arch: arm64
           - name: x86_64 macOS
             os: macos-13


### PR DESCRIPTION
These runners are [now available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) for OSS projects, and should be a lot faster than using QEMU for emulation.

- `metatensor-core` wheel now takes 2min instead of 9min30s
- `metatensor-torch` wheel now takes 3min instead of 25min!

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2456690745.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2456722196.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Build Python wheels wheels start -->
[⚙️ Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2456951962.zip)

<!-- download-section Build Python wheels wheels end -->