### PR TITLE
Disable `PicoCentauri/comment-artifact@v1` when running from forks

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -377,6 +377,7 @@ jobs:
 
       - name: Comment with download link
         uses: PicoCentauri/comment-artifact@v1
+        if: github.event.pull_request.head.repo.fork == false
         with:
           name: wheels
           description: ⚙️ Download Python wheels for this pull-request (you can install these with pip)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Comment with download link
         uses: PicoCentauri/comment-artifact@v1
+        if: github.event.pull_request.head.repo.fork == false
         with:
           name: docs
           description: 📚 Download documentation for this pull-request


### PR DESCRIPTION
This should fix CI here until the issue is resolved upstream!


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
