### PR TITLE
Some more speed improvement in metatensor-core library

### DIFF
--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -20,6 +20,10 @@ indexmap = "2"
 once_cell = "1"
 smallvec = {version = "1", features = ["union"]}
 
+# this is part of the standard library and stable since rust 1.84,
+# we can remove it when our MSRV is at least 1.84
+is_sorted = "0.1"
+
 # implementation of the MTS serialization format
 byteorder = {version = "1"}
 num-traits = {version = "0.2", default-features = false}

--- a/metatensor-core/src/labels.rs
+++ b/metatensor-core/src/labels.rs
@@ -170,6 +170,9 @@ pub struct Labels {
     names: Vec<ConstCString>,
     /// Values of the labels, as a linearized 2D array in row-major order
     values: Vec<LabelValue>,
+    /// Whether the entries of the labels (i.e. the rows of the 2D array) are
+    /// sorted in lexicographical order
+    sorted: bool,
     /// Store the position of all the known labels, for faster access later.
     /// This is lazily initialized whenever a function requires access to the
     /// positions of different entries, allowing to skip the construction of the
@@ -272,6 +275,7 @@ impl Labels {
             return Ok(Labels {
                 names: Vec::new(),
                 values: Vec::new(),
+                sorted: true,
                 positions: Default::default(),
                 user_data: RwLock::new(UserData::null()),
             });
@@ -281,10 +285,10 @@ impl Labels {
         assert!(values.len() % size == 0);
 
         if check_unique {
-            let mut vec_ref = values.chunks_exact(size).collect::<Vec<_>>();
-            vec_ref.sort_unstable();
-            if let Some(identical) = vec_ref.windows(2).position(|w| w[0] == w[1]) {
-                let entry = vec_ref[identical];
+            let mut entries = values.chunks_exact(size).collect::<Vec<_>>();
+            entries.sort_unstable();
+            if let Some(identical) = entries.windows(2).position(|w| w[0] == w[1]) {
+                let entry = entries[identical];
                 let entry_display = entry.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", ");
                 return Err(Error::InvalidParameter(format!(
                     "can not have the same label entry multiple time: [{}] is already present",
@@ -293,9 +297,11 @@ impl Labels {
             }
         }
 
+        let sorted = is_sorted::IsSorted::is_sorted(&mut values.chunks_exact(size));
         Ok(Labels {
             names: names,
             values: values,
+            sorted: sorted,
             positions: OnceCell::new(),
             user_data: RwLock::new(UserData::null()),
         })
@@ -315,6 +321,11 @@ impl Labels {
     /// C-compatible (null terminated) strings
     pub fn c_names(&self) -> &[ConstCString] {
         &self.names
+    }
+
+    /// Check whether entries in these Labels are sorted in lexicographic order
+    pub fn is_sorted(&self) -> bool {
+        self.sorted
     }
 
     /// Get the registered user data (this will be NULL if no data was
@@ -429,9 +440,11 @@ impl Labels {
             }
         }
 
+        let sorted = is_sorted::IsSorted::is_sorted(&mut values.chunks_exact(self.size()));
         return Ok(Labels {
             names: self.names.clone(),
             values,
+            sorted: sorted,
             positions: OnceCell::with_value(positions),
             user_data: RwLock::new(UserData::null()),
         });
@@ -484,9 +497,20 @@ impl Labels {
             }
         }
 
+        let sorted = if first.is_sorted() {
+            // if the input was sorted, the output will be as well, since we
+            // can only remove entries
+            true
+        } else {
+            // we need to check, since the removed entries could be the ones out
+            // of order
+            is_sorted::IsSorted::is_sorted(&mut values.chunks_exact(self.size()))
+        };
+
         return Ok(Labels {
             names: self.names.clone(),
             values,
+            sorted: sorted,
             positions: OnceCell::new(),
             user_data: RwLock::new(UserData::null()),
         });
@@ -627,6 +651,21 @@ mod tests {
 
         let e = Labels::new(&["not", "there", "not"], Vec::<i32>::new()).err().unwrap();
         assert_eq!(e.to_string(), "invalid parameter: labels names must be unique, got 'not' multiple times");
+    }
+
+    #[test]
+    fn sorted() {
+        let labels = Labels::new(&["aa", "bb"],
+            vec![0, 1, /**/ 1, 2]
+        ).unwrap();
+
+        assert!(labels.is_sorted());
+
+        let labels = Labels::new(&["aa", "bb"],
+            vec![0, 1, /**/ 1, 2, /**/ 0, 2]
+        ).unwrap();
+
+        assert!(!labels.is_sorted());
     }
 
     #[test]

--- a/python/metatensor_core/tests/blocks.py
+++ b/python/metatensor_core/tests/blocks.py
@@ -100,8 +100,8 @@ def test_gradient_errors(block):
     )
 
     message = (
-        "invalid parameter: invalid value for the 'sample' in gradient samples: "
-        "we got -3, but the values contain 3 samples"
+        "invalid parameter: invalid value for the 'sample' dimension "
+        "in gradient samples: all values should be positive, but we got -3"
     )
     with pytest.raises(MetatensorError, match=message):
         block.add_gradient("g", gradient)
@@ -115,8 +115,8 @@ def test_gradient_errors(block):
     )
 
     message = (
-        "invalid parameter: invalid value for the 'sample' in gradient samples: "
-        "we got 42, but the values contain 3 samples"
+        "invalid parameter: invalid value for the 'sample' dimension "
+        "in gradient samples: we got 42, but the values contain 3 samples"
     )
     with pytest.raises(MetatensorError, match=message):
         block.add_gradient("g", gradient)


### PR DESCRIPTION
This is a follow up to #820, addressing #818; but this time modifying the underlying Rust code to give everyone the same speed up. The biggest change is adding the `is_lexicographically_sorted` flag discussed in #142 (for now only as an internal flag, we can expose it as part of the public API later), and using it to make gradient sample checks a lot faster. 

With this, I get the following profile on the script from #818:

```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    79                                               @profile
    80                                               def compute_with_gradients(self, xyz: TensorMap) -> TensorMap:
    81                                                   """
    82                                                   Computes the spherical harmonics for the given Cartesian coordinates, up to
    83                                                   the maximum degree ``l_max`` specified during initialization,
    84                                                   together with their gradients with respect to the Cartesian coordinates.
    85
    86                                                   :param xyz: see :py:meth:`compute`
    87
    88                                                   :return: The spherical harmonics and their metadata as a
    89                                                       :py:class:`metatensor.TensorMap`. Each ``TensorBlock`` in the output
    90                                                       ``TensorMap`` will have a gradient block with respect to the Cartesian
    91                                                       positions. All ``samples`` in the output ``TensorMap`` will be the same as
    92                                                       those of the ``xyz`` input.
    93                                                   """
    94       510         45.6      0.1      1.7          _check_xyz_tensor_map(xyz)
    95      1020       2112.6      2.1     79.9          sh_values, sh_gradients = self.raw_calculator.compute_with_gradients(
    96       510         23.3      0.0      0.9              xyz.block().values.squeeze(-1)
    97                                                   )
    98      1020        413.5      0.4     15.6          return _wrap_into_tensor_map(
    99       510          0.1      0.0      0.0              sh_values,
   100       510          0.2      0.0      0.0              self.precomputed_keys,
   101       510         49.7      0.1      1.9              xyz.block().samples,
   102       510          0.1      0.0      0.0              self.precomputed_mu_components,
   103       510          0.0      0.0      0.0              self.precomputed_xyz_components,
   104       510          0.0      0.0      0.0              self.precomputed_xyz_2_components,
   105       510          0.0      0.0      0.0              self.precomputed_properties,
   106       510          0.0      0.0      0.0              sh_gradients,
   107                                                   )
```

i.e. 80% of the time is now spent in sphericart, and only 20% in metatensor. 


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
