### PR TITLE
Use $ORIGIN/@loader_path in metatensor_torch install rpath

### DIFF
--- a/python/metatensor_torch/CMakeLists.txt
+++ b/python/metatensor_torch/CMakeLists.txt
@@ -62,4 +62,18 @@ else()
     message(STATUS "Using internal metatensor-torch from ${METATENSOR_TORCH_SOURCE_DIR}")
 
     add_subdirectory("${METATENSOR_TORCH_SOURCE_DIR}" metatensor-torch)
+
+    if (LINUX)
+        set_target_properties(
+            # when loading the libraries from a Python installation,
+            # $ORIGIN/../../../lib is where libmetatensor.so will be, and
+            # $ORIGIN/../../../../torch/lib is where libtorch.so will be.
+            metatensor_torch PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH};$ORIGIN/../../../lib;$ORIGIN/../../../../torch/lib"
+        )
+    elseif(APPLE)
+        set_target_properties(
+            # same as above, but `$ORIGIN` is `@loader_path` on macOS
+            metatensor_torch PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH};@loader_path/../../../lib;@loader_path/../../../../torch/lib"
+        )
+    endif()
 endif()


### PR DESCRIPTION
This makes sure that code consuming a `metatensor_torch` installation from PyPI will be able to find metatensor and torch.(i.e. https://github.com/metatensor/metatomic/pull/1)


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
