### PR TITLE
Make sure a recent-enough version of setuptools is installed by tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,9 @@ test_options =
     --import-mode=append
 
 packaging_deps =
-    setuptools
+    setuptools >=75
     setuptools-scm
-    packaging
+    packaging >= 23
     cmake
 
 testing_deps =


### PR DESCRIPTION
Otherwise `virtualenv` might re-use an old installation and fail the build down the line.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
