### PR TITLE
Implement label difference in metatensor core

### DIFF
--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,6 +17,10 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
+### Added
+
+- `Labels::difference` for finding the set difference between two labels (#710)
+
 ### metatensor-core Julia
 
 #### Added

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -19,7 +19,7 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ### Added
 
-- `Labels::difference` for finding the set difference between two labels (#710)
+- `Labels::difference` for finding the set difference between two labels (#710).
 
 ### metatensor-core Julia
 

--- a/metatensor-core/tests/cpp/labels.cpp
+++ b/metatensor-core/tests/cpp/labels.cpp
@@ -117,6 +117,27 @@ TEST_CASE("Set operations") {
         CHECK(second_mapping == expected);
     }
 
+    SECTION("difference") {
+        auto first = Labels({"aa", "bb"}, {{0, 1}, {1, 2}});
+        auto second = Labels({"aa", "bb"}, {{2, 3}, {1, 2}, {4, 5}});
+
+        auto first_mapping = std::vector<int64_t>(first.count());
+
+        auto difference = first.set_difference(second, first_mapping);
+
+        CHECK(difference.size() == 4);
+        CHECK(difference.names()[0] == std::string("aa"));
+        CHECK(difference.names()[1] == std::string("bb"));
+
+        CHECK(difference.count() == 2);
+        const auto& values = difference.values();
+        CHECK(values(0, 0) == 0);
+        CHECK(values(0, 1) == 1);
+
+        auto expected = std::vector<int64_t>{0, -1};
+        CHECK(first_mapping == expected);
+    }
+
     SECTION("select") {
         // selection with a subset of names
         auto labels = Labels({"aa", "bb"}, {{1, 1}, {1, 2}, {3, 2}, {2, 1}});


### PR DESCRIPTION
Partially fixes #710. 
Implement the set difference function for `Labels` in `metatensor-core`.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
