### PR TITLE
Fixed copy paste error in intersection function description

### DIFF
--- a/metatensor-core/include/metatensor.h
+++ b/metatensor-core/include/metatensor.h
@@ -421,7 +421,7 @@ mts_status_t mts_labels_union(struct mts_labels_t first,
  *
  * @param first first set of labels
  * @param second second set of labels
- * @param result empty labels, on output will contain the union of `first` and
+ * @param result empty labels, on output will contain the intersection of `first` and
  *        `second`
  * @param first_mapping if you want the mapping from the positions of entries
  *        in `first` to the positions in `result`, this should be a pointer to

--- a/metatensor-core/src/c_api/labels.rs
+++ b/metatensor-core/src/c_api/labels.rs
@@ -469,7 +469,7 @@ pub unsafe extern fn mts_labels_union(
 ///
 /// @param first first set of labels
 /// @param second second set of labels
-/// @param result empty labels, on output will contain the union of `first` and
+/// @param result empty labels, on output will contain the intersection of `first` and
 ///        `second`
 /// @param first_mapping if you want the mapping from the positions of entries
 ///        in `first` to the positions in `result`, this should be a pointer to


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Just changed a copy-paste error in the c_api, it should be 'intersection' for the intersection function not 'union'

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2547101893.zip)

<!-- download-section Documentation docs end -->