### PR TITLE
Update setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 
 [build-system]
 requires = [
-    "setuptools >=68",
+    "setuptools >=71",
     "packaging >=23",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Setuptools 68, 69 and 70 fail to build the library
