### PR TITLE
Release metatensor-core v0.1.12

### DIFF
--- a/docs/src/core/reference/c/index.rst
+++ b/docs/src/core/reference/c/index.rst
@@ -12,6 +12,7 @@ C API reference
     :tag-prefix: metatensor-core-v
     :url-suffix: core/reference/c/index.html
 
+    .. version:: 0.1.12
     .. version:: 0.1.11
     .. version:: 0.1.10
     .. version:: 0.1.9

--- a/docs/src/core/reference/cxx/index.rst
+++ b/docs/src/core/reference/cxx/index.rst
@@ -12,6 +12,7 @@ C++ API reference
     :tag-prefix: metatensor-core-v
     :url-suffix: core/reference/cxx/index.html
 
+    .. version:: 0.1.12
     .. version:: 0.1.11
     .. version:: 0.1.10
     .. version:: 0.1.9

--- a/docs/src/core/reference/python/index.rst
+++ b/docs/src/core/reference/python/index.rst
@@ -12,6 +12,7 @@ Python API reference
     :tag-prefix: metatensor-core-v
     :url-suffix: core/reference/python/index.html
 
+    .. version:: 0.1.12
     .. version:: 0.1.11
     .. version:: 0.1.10
     .. version:: 0.1.9

--- a/metatensor-core/CHANGELOG.md
+++ b/metatensor-core/CHANGELOG.md
@@ -17,15 +17,17 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 #### Removed
 -->
 
-### Changed
-
-- The default extension for file serialization is now `.mts` instead of `.npz`
-
 ### metatensor-core Julia
 
 #### Added
 
 - the Julia bindings to metatensor-core in the Metatensor.jl package
+
+## [Version 0.1.12](https://github.com/metatensor/metatensor/releases/tag/metatensor-core-v0.1.12) - 2025-02-17
+
+### Changed
+
+- The default extension for file serialization is now `.mts` instead of `.npz`
 
 ## [Version 0.1.11](https://github.com/metatensor/metatensor/releases/tag/metatensor-core-v0.1.11) - 2024-10-23
 

--- a/metatensor-core/Cargo.toml
+++ b/metatensor-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metatensor-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 publish = false
 rust-version = "1.74"

--- a/metatensor-core/tests/cmake-project/CMakeLists.txt
+++ b/metatensor-core/tests/cmake-project/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     # If building a dev version, we also need to update the REQUIRED_METATENSOR_VERSION
     # in the same way we update the metatensor-torch version
     include(../../cmake/dev-versions.cmake)
-    set(REQUIRED_METATENSOR_VERSION "0.1.11")
+    set(REQUIRED_METATENSOR_VERSION "0.1.12")
     create_development_version("${REQUIRED_METATENSOR_VERSION}" METATENSOR_CORE_FULL_VERSION "metatensor-core-v")
     string(REGEX REPLACE "([0-9]*)\\.([0-9]*).*" "\\1.\\2" REQUIRED_METATENSOR_VERSION ${METATENSOR_CORE_FULL_VERSION})
 

--- a/metatensor-torch/CMakeLists.txt
+++ b/metatensor-torch/CMakeLists.txt
@@ -72,7 +72,7 @@ function(check_compatible_versions _actual_ _requested_)
 endfunction()
 
 
-set(REQUIRED_METATENSOR_VERSION "0.1.11")
+set(REQUIRED_METATENSOR_VERSION "0.1.12")
 if (NOT "$ENV{METATENSOR_NO_LOCAL_DEPS}" STREQUAL "1")
     # If building a dev version, we also need to update the
     # REQUIRED_METATENSOR_VERSION in the same way we update the metatensor-torch

--- a/python/metatensor_core/CMakeLists.txt
+++ b/python/metatensor_core/CMakeLists.txt
@@ -14,7 +14,7 @@ set(METATENSOR_CORE_SOURCE_DIR "" CACHE PATH "Path to the sources of metatensor-
 
 file(REMOVE ${CMAKE_INSTALL_PREFIX}/_external.py)
 
-set(REQUIRED_METATENSOR_VERSION "0.1.11")
+set(REQUIRED_METATENSOR_VERSION "0.1.12")
 if(${METATENSOR_CORE_PYTHON_USE_EXTERNAL_LIB})
     # when building a source checkout, update version to include git information
     # this will not apply when building a sdist

--- a/rust/metatensor-sys/Cargo.toml
+++ b/rust/metatensor-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metatensor-sys"
 # This should be kept in sync with metatensor-core version number
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 rust-version = "1.74"
 


### PR DESCRIPTION
Changed the default extension for file serialization is now `.mts` instead of `.npz`. This change is backward compatible since `npz`/`mts` is basically a ZIP folder. 

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2603991978.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Build Python wheels wheels start -->
[⚙️ Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2604211512.zip)

<!-- download-section Build Python wheels wheels end -->