### PR TITLE
Release metatensor-operations v0.3.2

### DIFF
--- a/docs/src/operations/reference/index.rst
+++ b/docs/src/operations/reference/index.rst
@@ -13,6 +13,7 @@ API reference
     :tag-prefix: metatensor-operations-v
     :url-suffix: operations/reference/index.html
 
+    .. version:: 0.3.2
     .. version:: 0.3.1
     .. version:: 0.3.0
     .. version:: 0.2.4

--- a/python/metatensor_operations/CHANGELOG.md
+++ b/python/metatensor_operations/CHANGELOG.md
@@ -17,6 +17,13 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.3.2](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.3.2) - 2025-02-18
+
+### Fixed
+
+- `mean_over_samples` was not computing the correct mean
+
+
 ## [Version 0.3.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.3.1) - 2025-02-04
 
 ### Added

--- a/python/metatensor_operations/setup.py
+++ b/python/metatensor_operations/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.sdist import sdist
 ROOT = os.path.realpath(os.path.dirname(__file__))
 METATENSOR_CORE = os.path.realpath(os.path.join(ROOT, "..", "metatensor_core"))
 
-METATENSOR_OPERATIONS_VERSION = "0.3.1"
+METATENSOR_OPERATIONS_VERSION = "0.3.2"
 
 
 class bdist_egg_disabled(bdist_egg):


### PR DESCRIPTION
This release fixes a severe bug in `mean_over_samples`.

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2607315262.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Build Python wheels wheels start -->
[⚙️ Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2607379241.zip)

<!-- download-section Build Python wheels wheels end -->