### PR TITLE
Bump backend Python version when building wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: "3.13"
 
       - name: install dependencies
         run: python -m pip install cibuildwheel


### PR DESCRIPTION
Bumped the version in the build-wheels action to be consistent with all other Python versions

This change does not affect the actual build process of the wheels! Each wheel is run in an independent docker container set up by `cibuildwheel`.


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2609044419.zip)

<!-- download-section Documentation docs end -->

<!-- download-section Build Python wheels wheels start -->
[⚙️ Download Python wheels for this pull-request (you can install these with pip)](https://nightly.link/metatensor/metatensor/actions/artifacts/2609149930.zip)

<!-- download-section Build Python wheels wheels end -->