### PR TITLE
Only calculate stress if PBCs are there

### DIFF
--- a/python/metatensor_torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor_torch/metatensor/torch/atomistic/ase_calculator.py
@@ -295,7 +295,9 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
         )
         calculate_energies = "energies" in properties
         calculate_forces = "forces" in properties or "stress" in properties
-        calculate_stress = "stress" in properties or "forces" in properties
+        calculate_stress = (
+            "stress" in properties or "forces" in properties
+        ) and atoms.pbc.all()
         if "stresses" in properties:
             raise NotImplementedError("'stresses' are not implemented yet")
 

--- a/python/metatensor_torch/metatensor/torch/atomistic/ase_calculator.py
+++ b/python/metatensor_torch/metatensor/torch/atomistic/ase_calculator.py
@@ -295,9 +295,18 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
         )
         calculate_energies = "energies" in properties
         calculate_forces = "forces" in properties or "stress" in properties
-        calculate_stress = (
-            "stress" in properties or "forces" in properties
-        ) and atoms.pbc.all()
+        calculate_stress = "stress" in properties
+        if calculate_stress and not atoms.pbc.all():
+            warnings.warn(
+                "stress requested but likely to be wrong, since the system is not "
+                "periodic in all directions",
+                stacklevel=2,
+            )
+        if "forces" in properties and atoms.pbc.all():
+            # we have PBCs, and, since the user/integrator requested forces, we will run
+            # backward anyway, so let's do the stress as well for free (this saves
+            # another forward-backward call later if the stress is requested)
+            calculate_stress = True
         if "stresses" in properties:
             raise NotImplementedError("'stresses' are not implemented yet")
 


### PR DESCRIPTION
As in the title, otherwise the stress is +inf or -inf, and warnings are displayed when we convert those to Voigt stresses

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2615423377.zip)

<!-- download-section Documentation docs end -->