### PR TITLE
Make the ASE calculator warn for high uncertainties

### DIFF
--- a/python/metatensor_torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor_torch/tests/atomistic/ase_calculator.py
@@ -132,6 +132,18 @@ def test_get_properties(model, atoms):
     assert np.all(properties["stress"] == atoms.get_stress())
 
 
+def test_accuracy_warning(model, atoms):
+    # our dummy model artificially gives a high uncertainty for large structures
+    big_atoms = atoms * (2, 2, 2)
+    big_atoms.calc = MetatensorCalculator(model, check_consistency=True)
+
+    with pytest.warns(
+        UserWarning,
+        match="this prediction is not chemically accurate",
+    ):
+        big_atoms.get_forces()
+
+
 def test_run_model(tmpdir, model, atoms):
     ref = atoms.copy()
     ref.calc = ase.calculators.lj.LennardJones(


### PR DESCRIPTION
Adds uncertainty warnings to the ASE calculator. The threshold is set to 0.1 eV/atom, which is "chemical accuracy", according to some. The tests need https://github.com/metatensor/lj-test/pull/5 to work correctly

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
