### PR TITLE
Maintain the order of the filtering keys in `filter_blocks`

### DIFF
--- a/python/metatensor_operations/metatensor/operations/filter_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/filter_blocks.py
@@ -46,9 +46,7 @@ def filter_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> Tensor
     # Create the new TensorMap
     new_blocks: List[TensorBlock] = []
     new_keys_values = []
-    for i in range(len(tensor_keys)):
-        if i not in to_keep_indices:
-            continue
+    for i in to_keep_indices:
 
         new_keys_values.append(tensor_keys.entry(i).values)
         block = tensor[i]

--- a/python/metatensor_operations/metatensor/operations/filter_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/filter_blocks.py
@@ -47,7 +47,6 @@ def filter_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> Tensor
     new_blocks: List[TensorBlock] = []
     new_keys_values = []
     for i in to_keep_indices:
-
         new_keys_values.append(tensor_keys.entry(i).values)
         block = tensor[i]
 

--- a/python/metatensor_operations/tests/filter_blocks.py
+++ b/python/metatensor_operations/tests/filter_blocks.py
@@ -17,6 +17,8 @@ def tensor() -> TensorMap:
 
 def test_keep_all(tensor):
     full_tensor = metatensor.filter_blocks(tensor, tensor.keys)
+
+    assert tensor.keys == full_tensor.keys
     assert metatensor.equal(tensor, full_tensor)
 
 
@@ -51,6 +53,7 @@ def test_keep_two_random_keys(tensor):
     ref_tensor = TensorMap(keys_to_keep, ref_blocks)
 
     new_tensor = metatensor.filter_blocks(tensor, keys_to_keep)
+    assert ref_tensor.keys == new_tensor.keys
     assert metatensor.equal(new_tensor, ref_tensor)
 
 
@@ -65,6 +68,7 @@ def test_larger_filter(tensor):
     )
     test_filter = metatensor.filter_blocks(tensor, key_to_filter)
 
+    assert test_filter.keys == tensor.keys
     assert metatensor.equal(test_filter, tensor)
 
 
@@ -88,6 +92,7 @@ def test_copy_flag(tensor):
     new_tensor_not_copied = metatensor.filter_blocks(tensor, keys_to_keep, copy=False)
 
     # Check that the resulting tensor are equal whether or not they are copied
+    assert new_tensor_copied.keys == new_tensor_not_copied.keys
     assert metatensor.equal(new_tensor_copied, new_tensor_not_copied)
 
     # Now modify the original tensor's block values in place


### PR DESCRIPTION
This ensures that when all the filtering `keys` are present in the `tensor` to be filtered, the resulting `TensorMap` has keys whose order matches those in the `keys` passed to `filter_blocks`


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - ~[ ] Documentation updated (for new features)?~
 - ~[ ] Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2859051658.zip)

<!-- download-section Documentation docs end -->