### PR TITLE
Improve speed of atomic type check

### DIFF
--- a/python/metatensor_torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor_torch/metatensor/torch/atomistic/model.py
@@ -393,16 +393,24 @@ class MetatensorAtomisticModel(torch.nn.Module):
                     expected_dtype=self._model_dtype,
                 )
 
-        for system in systems:
+        with record_function("MetatensorAtomisticModel::check_atomic_types"):
             # always (i.e. even if check_consistency=False) check that the atomic types
             # of the system match the one the model supports
-            all_types = torch.unique(system.types)
-            for atom_type in all_types:
-                if atom_type not in self._capabilities.atomic_types:
-                    raise ValueError(
-                        "this model does not support the atomic type "
-                        f"'{atom_type.item()}' which is present in the input systems"
-                    )
+            all_types = torch.cat([system.types for system in systems])
+            unsupported_mask = torch.logical_not(
+                torch.isin(
+                    all_types,
+                    torch.tensor(
+                        self._capabilities.atomic_types, device=all_types.device
+                    ),
+                )
+            )
+            if torch.any(unsupported_mask):
+                atom_type = all_types[unsupported_mask][0]
+                raise ValueError(
+                    "this model does not support the atomic type "
+                    f"'{atom_type.item()}' which is present in the input systems"
+                )
 
         # convert systems from engine to model units
         with record_function("MetatensorAtomisticModel::convert_units_input"):

--- a/python/metatensor_torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor_torch/metatensor/torch/atomistic/model.py
@@ -396,21 +396,22 @@ class MetatensorAtomisticModel(torch.nn.Module):
         with record_function("MetatensorAtomisticModel::check_atomic_types"):
             # always (i.e. even if check_consistency=False) check that the atomic types
             # of the system match the one the model supports
-            all_types = torch.cat([system.types for system in systems])
-            unsupported_mask = torch.logical_not(
-                torch.isin(
-                    all_types,
-                    torch.tensor(
-                        self._capabilities.atomic_types, device=all_types.device
-                    ),
+            if len(systems) > 0:
+                all_types = torch.cat([system.types for system in systems])
+                unsupported_mask = torch.logical_not(
+                    torch.isin(
+                        all_types,
+                        torch.tensor(
+                            self._capabilities.atomic_types, device=all_types.device
+                        ),
+                    )
                 )
-            )
-            if torch.any(unsupported_mask):
-                atom_type = all_types[unsupported_mask][0]
-                raise ValueError(
-                    "this model does not support the atomic type "
-                    f"'{atom_type.item()}' which is present in the input systems"
-                )
+                if torch.any(unsupported_mask):
+                    atom_type = all_types[unsupported_mask][0]
+                    raise ValueError(
+                        "this model does not support the atomic type "
+                        f"'{atom_type.item()}' which is present in the input systems"
+                    )
 
         # convert systems from engine to model units
         with record_function("MetatensorAtomisticModel::convert_units_input"):

--- a/python/metatensor_torch/tests/atomistic/model.py
+++ b/python/metatensor_torch/tests/atomistic/model.py
@@ -4,11 +4,13 @@ from typing import Dict, List, Optional
 
 import pytest
 import torch
+from packaging import version
 
 from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatensor.torch.atomistic import (
     MetatensorAtomisticModel,
     ModelCapabilities,
+    ModelEvaluationOptions,
     ModelMetadata,
     ModelOutput,
     NeighborListOptions,
@@ -29,16 +31,16 @@ class MinimalModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
-        if "dummy" in outputs:
+        if "tests::dummy::long" in outputs:
             block = TensorBlock(
-                values=torch.tensor([[0.0]]),
+                values=torch.tensor([[0.0]], dtype=torch.float64),
                 samples=Labels("s", torch.tensor([[0]])),
                 components=torch.jit.annotate(List[Labels], []),
                 properties=Labels("p", torch.tensor([[0]])),
             )
             tensor = TensorMap(Labels("_", torch.tensor([[0]])), [block])
             return {
-                "dummy": tensor,
+                "tests::dummy::long": tensor,
             }
         else:
             return {}
@@ -407,3 +409,49 @@ def test_read_metadata(tmpdir):
     extracted_metadata = read_model_metadata(str(tmpdir / "model.pt"))
 
     assert str(extracted_metadata) == str(metadata)
+
+
+@pytest.mark.parametrize("n_systems", [0, 1, 2, 3])
+def test_predictions(model, tmp_path, n_systems):
+    os.chdir(tmp_path)
+    model.save("export.pt")
+    model_loaded = load_atomistic_model("export.pt")
+
+    system = System(
+        positions=torch.tensor([[0.0, 0.0, 0.0]], dtype=torch.float64),
+        types=torch.tensor([1]),
+        cell=torch.tensor(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=torch.float64
+        ),
+        pbc=torch.tensor([True, True, True]),
+    )
+    requested_neighbor_lists = model_loaded.requested_neighbor_lists()
+    for requested_neighbor_list in requested_neighbor_lists:
+        system.add_neighbor_list(
+            requested_neighbor_list,
+            TensorBlock(
+                values=torch.empty(0, 3, 1, dtype=torch.float64),
+                samples=Labels(
+                    [
+                        "first_atom",
+                        "second_atom",
+                        "cell_shift_a",
+                        "cell_shift_b",
+                        "cell_shift_c",
+                    ],
+                    torch.empty(0, 5, dtype=torch.int32),
+                ),
+                components=[Labels.range("xyz", 3)],
+                properties=Labels.range("distance", 1),
+            ),
+        )
+    systems = [system] * n_systems
+
+    outputs = {"tests::dummy::long": ModelOutput(quantity="", unit="", per_atom=False)}
+    evaluation_options = ModelEvaluationOptions(length_unit="angstrom", outputs=outputs)
+
+    result = model_loaded(systems, evaluation_options, check_consistency=True)
+    assert "tests::dummy::long" in result
+    assert isinstance(result["tests::dummy::long"], torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert result["tests::dummy::long"]._type().name() == "TensorMap"


### PR DESCRIPTION
On a structure of 250 atoms, this saves 0.5 ms

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2874057859.zip)

<!-- download-section Documentation docs end -->