### PR TITLE
Make sure `supported_types` has the same dtype as `all_types`

### DIFF
--- a/python/metatensor_torch/metatensor/torch/atomistic/model.py
+++ b/python/metatensor_torch/metatensor/torch/atomistic/model.py
@@ -398,13 +398,13 @@ class MetatensorAtomisticModel(torch.nn.Module):
             # of the system match the one the model supports
             if len(systems) > 0:
                 all_types = torch.cat([system.types for system in systems])
+                supported_types = torch.tensor(
+                    self._capabilities.atomic_types,
+                    device=all_types.device,
+                    dtype=all_types.dtype,
+                )
                 unsupported_mask = torch.logical_not(
-                    torch.isin(
-                        all_types,
-                        torch.tensor(
-                            self._capabilities.atomic_types, device=all_types.device
-                        ),
-                    )
+                    torch.isin(all_types, supported_types)
                 )
                 if torch.any(unsupported_mask):
                     atom_type = all_types[unsupported_mask][0]


### PR DESCRIPTION
Follow up to #886, otherwise the dtype of both array could not match in some cases, and I would get this error:

```
RuntimeError: Expected elements.dtype() == test_elements.dtype() to be true, but got false.
```

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
