### PR TITLE
Fix units for forces and stresses

### DIFF
--- a/metatensor-torch/src/atomistic/model.cpp
+++ b/metatensor-torch/src/atomistic/model.cpp
@@ -1070,13 +1070,13 @@ static std::map<std::string, Quantity> KNOWN_QUANTITIES = {
         {"J", "Joule"},
         {"Ry", "Rydberg"},
     }}},
-    {"forces", Quantity{/* name */ "forces", /* baseline */ "eV/Angstrom", {
+    {"force", Quantity{/* name */ "force", /* baseline */ "eV/Angstrom", {
         {"eV/Angstrom", 1.0},
     }, {
         // alternative names
         {"eV/A", "eV/Angstrom"},
     }}},
-    {"stress", Quantity{/* name */ "stress", /* baseline */ "eV/Angstrom^3", {
+    {"pressure", Quantity{/* name */ "pressure", /* baseline */ "eV/Angstrom^3", {
         {"eV/Angstrom^3", 1.0},
     }, {
         // alternative names

--- a/metatensor-torch/tests/atomistic.cpp
+++ b/metatensor-torch/tests/atomistic.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Models metadata") {
         struct WarningHandler: public torch::WarningHandler {
             virtual ~WarningHandler() override = default;
             void process(const torch::Warning& warning) override {
-                CHECK(warning.msg() == "unknown quantity 'unknown', only [energy forces length stress] are supported");
+                CHECK(warning.msg() == "unknown quantity 'unknown', only [energy force length pressure] are supported");
             }
         };
 


### PR DESCRIPTION
The units for `forces` should be `force`, not `forces`, and the units for `stress` should be `pressure`, not `stress`

<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatensor/actions/artifacts/2917764374.zip)

<!-- download-section Documentation docs end -->