### PR TITLE
Use SPDX license indentifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,13 @@ name = "metatensor"
 dynamic = ["version", "authors", "dependencies", "optional-dependencies"]
 
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 description = "Self-describing sparse tensor data format for atomistic machine learning and beyond"
 
 keywords = ["machine learning", "molecular modeling"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -34,7 +33,7 @@ changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 
 [build-system]
 requires = [
-    "setuptools >=75",
+    "setuptools >=77",
     "packaging >=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/metatensor_core/pyproject.toml
+++ b/python/metatensor_core/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version", "authors"]
 requires-python = ">=3.9"
 
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 description = "Python bindings for metatensor"
 
 dependencies = ["numpy"]
@@ -13,7 +13,6 @@ keywords = ["machine learning", "molecular modeling"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -36,7 +35,7 @@ changelog = "https://docs.metatensor.org/latest/core/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=75",
+    "setuptools >=77",
     "packaging >=23",
     "cmake",
 ]

--- a/python/metatensor_learn/pyproject.toml
+++ b/python/metatensor_learn/pyproject.toml
@@ -4,14 +4,13 @@ dynamic = ["version", "authors", "dependencies"]
 requires-python = ">=3.9"
 
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 description = "Building blocks for the atomistic machine learning models based on PyTorch and NumPy"
 
 keywords = ["machine learning", "molecular modeling"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -34,7 +33,7 @@ changelog = "https://docs.metatensor.org/latest/learn/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=75",
+    "setuptools >=77",
     "packaging >=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/metatensor_operations/pyproject.toml
+++ b/python/metatensor_operations/pyproject.toml
@@ -4,14 +4,13 @@ dynamic = ["version", "authors", "dependencies"]
 requires-python = ">=3.9"
 
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 description = "Operations to manipulate metatensor data types"
 
 keywords = ["machine learning", "molecular modeling"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -34,7 +33,7 @@ changelog = "https://docs.metatensor.org/latest/operations/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=75",
+    "setuptools >=77",
     "packaging >=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/metatensor_torch/pyproject.toml
+++ b/python/metatensor_torch/pyproject.toml
@@ -4,14 +4,13 @@ dynamic = ["version", "authors", "dependencies"]
 requires-python = ">=3.9"
 
 readme = "README.rst"
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 description = "TorchScript bindings for metatensor"
 
 keywords = ["machine learning", "molecular modeling", "torch"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
@@ -34,7 +33,7 @@ changelog = "https://docs.metatensor.org/latest/torch/CHANGELOG.html"
 ### ======================================================================== ###
 [build-system]
 requires = [
-    "setuptools >=75",
+    "setuptools >=77",
     "packaging >=23",
     "cmake",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ test_options =
     --import-mode=append
 
 packaging_deps =
-    setuptools >=75
+    setuptools >=77
     setuptools-scm
     packaging >= 23
     cmake


### PR DESCRIPTION
Setuptools is starting to warn about the old syntax being deprecated

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
