### PR TITLE
Do no re-allocate Labels values upon construction

### DIFF
--- a/metatensor-core/src/blocks.rs
+++ b/metatensor-core/src/blocks.rs
@@ -374,7 +374,7 @@ mod tests {
     use super::*;
 
     fn example_labels(name: &str, count: i32) -> Arc<Labels> {
-        return Arc::new(Labels::new(&[name], (0..count).collect()).expect("invalid labels"));
+        return Arc::new(Labels::new_i32(&[name], (0..count).collect()).expect("invalid labels"));
     }
 
     #[test]
@@ -457,7 +457,7 @@ mod tests {
         );
 
         let values = TestArray::new(vec![3, 1, 2]);
-        let component = Arc::new(Labels::new(
+        let component = Arc::new(Labels::new_i32(
             &["component_1", "component_2"],
             vec![0, 1],
         ).expect("invalid labels"));
@@ -481,7 +481,7 @@ mod tests {
             let mut block = TensorBlock::new(values, samples, vec![], properties.clone()).unwrap();
             assert!(block.gradients().is_empty());
 
-            let gradient_samples = Arc::new(Labels::new(
+            let gradient_samples = Arc::new(Labels::new_i32(
                 &["sample", "foo"],
                 vec![0, 0, /**/ 1, 1, /**/ 3, -2],
             ).expect("invalid labels"));

--- a/metatensor-core/src/c_api/labels.rs
+++ b/metatensor-core/src/c_api/labels.rs
@@ -104,7 +104,7 @@ unsafe fn create_rust_labels(labels: &mts_labels_t) -> Result<Arc<Labels>, Error
             return Err(Error::InvalidParameter("can not have labels.count > 0 if labels.size is 0".into()));
         }
 
-        let labels = Labels::new(&[], Vec::<i32>::new()).expect("invalid empty labels");
+        let labels = Labels::new(&[], Vec::<LabelValue>::new()).expect("invalid empty labels");
         return Ok(Arc::new(labels));
     }
 

--- a/metatensor-core/src/tensor/mod.rs
+++ b/metatensor-core/src/tensor/mod.rs
@@ -425,33 +425,33 @@ mod tests {
 
         let tensor = TensorMap::new(keys, blocks).unwrap();
 
-        let selection = Labels::new(&["key_1", "key_2"], vec![1, 1]).unwrap();
+        let selection = Labels::new_i32(&["key_1", "key_2"], vec![1, 1]).unwrap();
         assert_eq!(
             tensor.blocks_matching(&selection).unwrap(),
             [2]
         );
 
-        let selection = Labels::new(&["key_1"], vec![1]).unwrap();
+        let selection = Labels::new_i32(&["key_1"], vec![1]).unwrap();
         assert_eq!(
             tensor.blocks_matching(&selection).unwrap(),
             [2, 3]
         );
 
-        let selection = Labels::new(&["key_1"], Vec::<i32>::new()).unwrap();
+        let selection = Labels::new_i32(&["key_1"], vec![]).unwrap();
         let result = tensor.blocks_matching(&selection);
         assert_eq!(
             result.unwrap_err().to_string(),
             "invalid parameter: block selection must contain exactly one entry, got 0"
         );
 
-        let selection = Labels::new(&["key_1", "key_2"], vec![3, 4, 1, 2]).unwrap();
+        let selection = Labels::new_i32(&["key_1", "key_2"], vec![3, 4, 1, 2]).unwrap();
         let result = tensor.blocks_matching(&selection);
         assert_eq!(
             result.unwrap_err().to_string(),
             "invalid parameter: block selection must contain exactly one entry, got 2"
         );
 
-        let selection = Labels::new(&["key_3"], vec![1]).unwrap();
+        let selection = Labels::new_i32(&["key_3"], vec![1]).unwrap();
         let result = tensor.blocks_matching(&selection);
         assert_eq!(
             result.unwrap_err().to_string(),


### PR DESCRIPTION
`Labels::new` used to take `Vec<impl Into<LabelsValue>>` for convenience, assuming that in the case where data was already LabelsValue the allocation would be skipped. This is not the case, so I changed it and added a separate convenience function for the tests.

This cuts 160us out of 740us in an example building neighbor lists sample labels

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
