### PR TITLE
Better `isinstance_metatensor`

### DIFF
--- a/python/metatensor_learn/metatensor/learn/_backend.py
+++ b/python/metatensor_learn/metatensor/learn/_backend.py
@@ -43,20 +43,24 @@ def _version_at_least(version, expected):
     return version >= expected
 
 
-def is_metatensor_class(value, typ):
-    assert typ in (Labels, TensorBlock, TensorMap)
+def isinstance_metatensor(value, typename):
+    assert typename in ("Labels", "TensorBlock", "TensorMap")
 
-    if isinstance(value, typ):
-        return True
+    if _HAS_TORCH and isinstance(value, torch.ScriptObject):
+        is_metatensor_torch_class = "metatensor" in str(value._type())
+        if is_metatensor_torch_class:
+            warnings.warn(
+                "Trying to use code from ``metatensor.learn`` with objects from "
+                "metatensor-torch, you should use the code from "
+                "`metatensor.torch.learn` instead",
+                stacklevel=2,
+            )
+
+    if typename == "Labels":
+        return isinstance(value, Labels)
+    elif typename == "TensorBlock":
+        return isinstance(value, TensorBlock)
+    elif typename == "TensorMap":
+        return isinstance(value, TensorMap)
     else:
-        if _HAS_TORCH and isinstance(value, torch.ScriptObject):
-            is_metatensor_torch_class = "metatensor" in str(value._type())
-            if is_metatensor_torch_class:
-                warnings.warn(
-                    "Trying to use code from ``metatensor.learn`` with objects from "
-                    "metatensor-torch, you should use the code from "
-                    "`metatensor.torch.learn` instead",
-                    stacklevel=2,
-                )
-
         return False

--- a/python/metatensor_learn/metatensor/learn/nn/sequential.py
+++ b/python/metatensor_learn/metatensor/learn/nn/sequential.py
@@ -3,7 +3,7 @@ from typing import List
 import torch
 from torch.nn import Module
 
-from .._backend import Labels, TensorMap, is_metatensor_class
+from .._backend import Labels, TensorMap, isinstance_metatensor
 from .module_map import ModuleMap
 
 
@@ -21,7 +21,7 @@ class Sequential(Module):
 
     def __init__(self, in_keys: Labels, *args: List[ModuleMap]):
         super().__init__()
-        if not is_metatensor_class(in_keys, Labels):
+        if not isinstance_metatensor(in_keys, "Labels"):
             raise TypeError("`in_keys` must be a `Labels` object.")
 
         modules: List[Module] = []

--- a/python/metatensor_operations/metatensor/operations/_backend.py
+++ b/python/metatensor_operations/metatensor/operations/_backend.py
@@ -68,21 +68,25 @@ def _version_at_least(version, expected):
     return version >= expected
 
 
-def is_metatensor_class(value, typ):
-    assert typ in (Labels, TensorBlock, TensorMap)
+def isinstance_metatensor(value, typename):
+    assert typename in ("Labels", "TensorBlock", "TensorMap")
 
-    if isinstance(value, typ):
-        return True
+    if _HAS_TORCH and isinstance(value, torch.ScriptObject):
+        is_metatensor_torch_class = "metatensor" in str(value._type())
+        if is_metatensor_torch_class:
+            warnings.warn(
+                "Trying to use operations from metatensor with objects from "
+                "metatensor-torch, you should use the operation from "
+                "`metatensor.torch` as well, e.g. `metatensor.torch.add(...)` "
+                "instead of `metatensor.add(...)`",
+                stacklevel=2,
+            )
+
+    if typename == "Labels":
+        return isinstance(value, Labels)
+    elif typename == "TensorBlock":
+        return isinstance(value, TensorBlock)
+    elif typename == "TensorMap":
+        return isinstance(value, TensorMap)
     else:
-        if _HAS_TORCH and isinstance(value, torch.ScriptObject):
-            is_metatensor_torch_class = "metatensor" in str(value._type())
-            if is_metatensor_torch_class:
-                warnings.warn(
-                    "Trying to use operations from metatensor with objects from "
-                    "metatensor-torch, you should use the operation from "
-                    "`metatensor.torch` as well, e.g. `metatensor.torch.add(...)` "
-                    "instead of `metatensor.add(...)`",
-                    stacklevel=2,
-                )
-
         return False

--- a/python/metatensor_operations/metatensor/operations/add.py
+++ b/python/metatensor_operations/metatensor/operations/add.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -104,14 +104,14 @@ def add(A: TensorMap, B: Union[int, float, TensorMap]) -> TensorMap:
     """
 
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(A, TensorMap):
+        if not isinstance_metatensor(A, "TensorMap"):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     blocks: List[TensorBlock] = []
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = is_metatensor_class(B, TensorMap)
+        is_tensor_map = isinstance_metatensor(B, "TensorMap")
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor_operations/metatensor/operations/divide.py
+++ b/python/metatensor_operations/metatensor/operations/divide.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -100,7 +100,7 @@ def _divide_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlo
 @torch_jit_script
 def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(A, TensorMap):
+        if not isinstance_metatensor(A, "TensorMap"):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     r"""Return a new :class:`TensorMap` with the values being the element-wise
@@ -133,7 +133,7 @@ def divide(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = is_metatensor_class(B, TensorMap)
+        is_tensor_map = isinstance_metatensor(B, "TensorMap")
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor_operations/metatensor/operations/drop_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/drop_blocks.py
@@ -5,7 +5,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -29,12 +29,12 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
     """
     # Check arg types
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor, TensorMap):
+        if not isinstance_metatensor(tensor, "TensorMap"):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
 
-        if not is_metatensor_class(keys, Labels):
+        if not isinstance_metatensor(keys, "Labels"):
             raise TypeError(f"`keys` must be a metatensor Labels, not {type(keys)}")
 
         if not isinstance(copy, bool):

--- a/python/metatensor_operations/metatensor/operations/equal_metadata.py
+++ b/python/metatensor_operations/metatensor/operations/equal_metadata.py
@@ -7,7 +7,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -25,9 +25,9 @@ def _equal_metadata_impl(
     check: Union[List[str], str] = "all",
 ) -> str:
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor_1, TensorMap):
+        if not isinstance_metatensor(tensor_1, "TensorMap"):
             return f"`tensor_1` must be a metatensor TensorMap, not {type(tensor_1)}"
-        if not is_metatensor_class(tensor_2, TensorMap):
+        if not isinstance_metatensor(tensor_2, "TensorMap"):
             return f"`tensor_2` must be a metatensor TensorMap, not {type(tensor_2)}"
 
     message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
@@ -48,9 +48,9 @@ def _equal_metadata_block_impl(
     check: Union[List[str], str] = "all",
 ) -> str:
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(block_1, TensorBlock):
+        if not isinstance_metatensor(block_1, "TensorBlock"):
             return f"`block_1` must be a metatensor TensorBlock, not {type(block_1)}"
-        if not is_metatensor_class(block_2, TensorBlock):
+        if not isinstance_metatensor(block_2, "TensorBlock"):
             return f"`block_2` must be a metatensor TensorBlock, not {type(block_2)}"
 
     check_blocks_message = _check_blocks_impl(

--- a/python/metatensor_operations/metatensor/operations/filter_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/filter_blocks.py
@@ -5,7 +5,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -29,12 +29,12 @@ def filter_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> Tensor
     """
     # Check arg types
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor, TensorMap):
+        if not isinstance_metatensor(tensor, "TensorMap"):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
 
-        if not is_metatensor_class(keys, Labels):
+        if not isinstance_metatensor(keys, "Labels"):
             raise TypeError(f"`keys` must be a metatensor Labels, not {type(keys)}")
 
         if not isinstance(copy, bool):

--- a/python/metatensor_operations/metatensor/operations/join.py
+++ b/python/metatensor_operations/metatensor/operations/join.py
@@ -5,7 +5,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -353,7 +353,7 @@ def join(
             raise TypeError(f"`tensor` must be a list or a tuple, not {type(tensors)}")
 
         for tensor in tensors:
-            if not is_metatensor_class(tensor, TensorMap):
+            if not isinstance_metatensor(tensor, "TensorMap"):
                 raise TypeError(
                     "`tensors` elements must be metatensor TensorMap, "
                     f"not {type(tensor)}"

--- a/python/metatensor_operations/metatensor/operations/multiply.py
+++ b/python/metatensor_operations/metatensor/operations/multiply.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -121,14 +121,14 @@ def multiply(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(A, TensorMap):
+        if not isinstance_metatensor(A, "TensorMap"):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     blocks: List[TensorBlock] = []
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = is_metatensor_class(B, TensorMap)
+        is_tensor_map = isinstance_metatensor(B, "TensorMap")
 
     if isinstance(B, (float, int)):
         B = float(B)

--- a/python/metatensor_operations/metatensor/operations/pow.py
+++ b/python/metatensor_operations/metatensor/operations/pow.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -76,7 +76,7 @@ def pow(A: TensorMap, B: Union[float, int]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(A, TensorMap):
+        if not isinstance_metatensor(A, "TensorMap"):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
         if not isinstance(B, (float, int)):

--- a/python/metatensor_operations/metatensor/operations/slice.py
+++ b/python/metatensor_operations/metatensor/operations/slice.py
@@ -6,7 +6,7 @@ from ._backend import (
     LabelsValues,
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -26,7 +26,7 @@ def _slice_block(
     else:
         if not torch_jit_is_scripting():
             # This should already have been checked
-            assert is_metatensor_class(selection, Labels)
+            assert isinstance_metatensor(selection, "Labels")
 
         if axis == "samples":
             selected = block.samples.select(selection)
@@ -168,7 +168,7 @@ def _check_slice_args(
             raise ValueError("`selection` must be a 1-D array of integers")
     elif not isinstance(selection, list):
         if not torch_jit_is_scripting():
-            if not is_metatensor_class(selection, Labels):
+            if not isinstance_metatensor(selection, "Labels"):
                 raise TypeError(
                     "`selection` must be metatensor Labels, an array "
                     + f"or List[int], not {type(selection)}"
@@ -223,7 +223,7 @@ def slice(tensor: TensorMap, axis: str, selection: Labels) -> TensorMap:
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor, TensorMap):
+        if not isinstance_metatensor(tensor, "TensorMap"):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -266,7 +266,7 @@ def slice_block(
     :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced input.
     """
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(block, TensorBlock):
+        if not isinstance_metatensor(block, "TensorBlock"):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor_operations/metatensor/operations/split.py
+++ b/python/metatensor_operations/metatensor/operations/split.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from ._backend import (
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -144,7 +144,7 @@ def split(
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor, TensorMap):
+        if not isinstance_metatensor(tensor, "TensorMap"):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -253,7 +253,7 @@ def split_block(
     """
     # Check input args
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(block, TensorBlock):
+        if not isinstance_metatensor(block, "TensorBlock"):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor_operations/metatensor/operations/subtract.py
+++ b/python/metatensor_operations/metatensor/operations/subtract.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from ._backend import (
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -37,13 +37,13 @@ def subtract(A: TensorMap, B: Union[float, int, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(A, TensorMap):
+        if not isinstance_metatensor(A, "TensorMap"):
             raise TypeError(f"`A` must be a metatensor TensorMap, not {type(A)}")
 
     if torch_jit_is_scripting():
         is_tensor_map = isinstance(B, TensorMap)
     else:
-        is_tensor_map = is_metatensor_class(B, TensorMap)
+        is_tensor_map = isinstance_metatensor(B, "TensorMap")
 
     if isinstance(B, (float, int)):
         B = -float(B)

--- a/python/metatensor_operations/metatensor/operations/unique_metadata.py
+++ b/python/metatensor_operations/metatensor/operations/unique_metadata.py
@@ -9,7 +9,7 @@ from ._backend import (
     Labels,
     TensorBlock,
     TensorMap,
-    is_metatensor_class,
+    isinstance_metatensor,
     torch_jit_is_scripting,
     torch_jit_script,
 )
@@ -164,7 +164,7 @@ def unique_metadata(
     """
     # Parse input args
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(tensor, TensorMap):
+        if not isinstance_metatensor(tensor, "TensorMap"):
             raise TypeError(
                 f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
             )
@@ -224,7 +224,7 @@ def unique_metadata_block(
     """
     # Parse input args
     if not torch_jit_is_scripting():
-        if not is_metatensor_class(block, TensorBlock):
+        if not isinstance_metatensor(block, "TensorBlock"):
             raise TypeError(
                 f"`block` must be a metatensor TensorBlock, not {type(block)}"
             )

--- a/python/metatensor_torch/metatensor/torch/operations.py
+++ b/python/metatensor_torch/metatensor/torch/operations.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from typing import Union
 
 import torch
 
@@ -71,23 +72,29 @@ else:
 module.__dict__["torch_jit_annotate"] = torch.jit.annotate
 
 
-def is_metatensor_class(value, typ):
+def isinstance_metatensor(value: Union[Labels, TensorBlock, TensorMap], typename: str):
+    assert typename in ("Labels", "TensorBlock", "TensorMap")
+
     if torch.jit.is_scripting():
-        return True
+        if typename == "Labels":
+            return isinstance(value, Labels)
+        elif typename == "TensorBlock":
+            return isinstance(value, TensorBlock)
+        elif typename == "TensorMap":
+            return isinstance(value, TensorMap)
 
-    assert typ in (Labels, TensorBlock, TensorMap)
+    # For custom classes (TensorMap, …), the `values` is an instance of
+    # `torch.ScriptObject` and not the class itself, so we use `_type`
+    # to get the type name
     if isinstance(value, torch.ScriptObject):
-        # For custom classes (TensorMap, …), the `typ` is an instance of
-        # `torch.ScriptClass` and not a class itself, and there is no way to check
-        # if obj is an "instance" of this class; so we always return True and hope
-        # for the best. Most errors should be caught by the TorchScript compiler
-        # anyway.
-        return True
-    else:
-        return False
+        qualified_name = value._type().qualified_name()
+        if qualified_name.startswith("__torch__.torch.classes.metatensor"):
+            return value._type().name() == typename
+
+    return False
 
 
-module.__dict__["is_metatensor_class"] = is_metatensor_class
+module.__dict__["isinstance_metatensor"] = isinstance_metatensor
 
 # register the module in sys.modules, so future import find it directly
 sys.modules[spec.name] = module

--- a/python/metatensor_torch/tests/atomistic/ase_calculator.py
+++ b/python/metatensor_torch/tests/atomistic/ase_calculator.py
@@ -32,6 +32,8 @@ from metatensor.torch.atomistic.ase_calculator import (
 from .. import _tests_utils
 
 
+PYTORCH_JIT_DISABLED = os.environ.get("PYTORCH_JIT") == "0"
+
 STR_TO_DTYPE = {
     "float32": torch.float32,
     "float64": torch.float64,
@@ -112,6 +114,7 @@ def test_torch_script_model(model, model_different_units, atoms):
     )
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_exported_model(tmpdir, model, model_different_units, atoms):
     path = os.path.join(tmpdir, "exported-model.pt")
     model.save(path)
@@ -137,6 +140,7 @@ def test_get_properties(model, atoms, non_conservative):
     assert np.all(properties["stress"] == atoms.get_stress())
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_run_model(tmpdir, model, atoms):
     ref = atoms.copy()
     ref.calc = ase.calculators.lj.LennardJones(
@@ -218,6 +222,7 @@ def test_run_model(tmpdir, model, atoms):
 
 
 @pytest.mark.parametrize("non_conservative", [True, False])
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_compute_energy(tmpdir, model, atoms, non_conservative):
     ref = atoms.copy()
     ref.calc = ase.calculators.lj.LennardJones(
@@ -267,6 +272,7 @@ def test_compute_energy(tmpdir, model, atoms, non_conservative):
     assert "stress" not in calculator.compute_energy(atoms_no_pbc)
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_serialize_ase(tmpdir, model, atoms):
     # Run some tests with a different dtype
     model._capabilities.dtype = "float32"
@@ -304,6 +310,7 @@ def test_serialize_ase(tmpdir, model, atoms):
         assert atoms.calc is not None
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_dtype_device(tmpdir, model, atoms):
     ref = atoms.copy()
     ref.calc = ase.calculators.lj.LennardJones(
@@ -340,6 +347,7 @@ def test_dtype_device(tmpdir, model, atoms):
         assert np.allclose(atoms.get_potential_energy(), expected)
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_model_with_extensions(tmpdir, atoms):
     ref = atoms.copy()
     ref.calc = ase.calculators.lj.LennardJones(

--- a/python/metatensor_torch/tests/atomistic/examples.py
+++ b/python/metatensor_torch/tests/atomistic/examples.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 
+import pytest
 import torch
 
 from metatensor.torch.atomistic import (
@@ -17,6 +18,7 @@ EXAMPLES = os.path.abspath(
 )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_export_atomistic_model(tmp_path):
     """test if model defined in `1-export-atomistic-model.py` can run"""
     os.chdir(tmp_path)

--- a/python/metatensor_torch/tests/atomistic/model.py
+++ b/python/metatensor_torch/tests/atomistic/model.py
@@ -21,6 +21,9 @@ from metatensor.torch.atomistic import (
 )
 
 
+PYTORCH_JIT_DISABLED = os.environ.get("PYTORCH_JIT") == "0"
+
+
 class MinimalModel(torch.nn.Module):
     """The simplest possible metatensor atomistic model"""
 
@@ -102,6 +105,7 @@ def model_energy_nounit():
     return MetatensorAtomisticModel(model_energy_nounit, metadata, capabilities)
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_save(model, tmp_path):
     os.chdir(tmp_path)
     model.save("export.pt")
@@ -113,6 +117,7 @@ def test_save(model, tmp_path):
     check_atomistic_model("export.pt")
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_recreate(model, tmp_path):
     os.chdir(tmp_path)
     model.save("export.pt")
@@ -135,6 +140,7 @@ def test_training_mode():
         MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_save_warning_length_unit(model):
     model._capabilities.length_unit = ""
     match = r"No length unit was provided for the model."
@@ -142,12 +148,14 @@ def test_save_warning_length_unit(model):
         model.save("export.pt")
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_save_warning_quantity(model_energy_nounit):
     match = r"No units were provided for output energy."
     with pytest.warns(UserWarning, match=match):
         model_energy_nounit.save("export.pt")
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_export(model, tmp_path):
     os.chdir(tmp_path)
     match = r"`export\(\)` is deprecated, use `save\(\)` instead"
@@ -208,6 +216,7 @@ class FullModel(torch.nn.Module):
         return result
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_requested_neighbor_lists(tmpdir):
     model = FullModel()
     model.train(False)
@@ -334,6 +343,7 @@ def test_bad_capabilities():
         ModelCapabilities(outputs={"not-a-standard::": ModelOutput()})
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_access_module(tmpdir):
     model = FullModel()
     model.train(False)
@@ -361,6 +371,7 @@ def test_access_module(tmpdir):
     loaded_atomistic.module.other
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_is_atomistic_model(tmpdir):
     model = FullModel()
     model.train(False)
@@ -386,6 +397,7 @@ def test_is_atomistic_model(tmpdir):
         is_atomistic_model(1.0)
 
 
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_read_metadata(tmpdir):
     model = FullModel()
     model.train(False)
@@ -411,6 +423,7 @@ def test_read_metadata(tmpdir):
 
 
 @pytest.mark.parametrize("n_systems", [0, 1, 8])
+@pytest.mark.skipif(PYTORCH_JIT_DISABLED, reason="requires TorchScript")
 def test_predictions(model, tmp_path, n_systems):
     os.chdir(tmp_path)
     model.save("export.pt")

--- a/python/metatensor_torch/tests/atomistic/systems.py
+++ b/python/metatensor_torch/tests/atomistic/systems.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import torch
 
@@ -511,9 +513,16 @@ def test_to(system, neighbors):
 
 # This function only works in script mode, because `block.dtype` is always an `int`, and
 # `torch.dtype` is only an int in script mode.
-@torch.jit.script
-def check_dtype(system: System, dtype: torch.dtype):
-    assert system.dtype == dtype
+if os.environ.get("PYTORCH_JIT") == "0":
+
+    def check_dtype(system: System, dtype: torch.dtype):
+        pass
+
+else:
+
+    @torch.jit.script
+    def check_dtype(system: System, dtype: torch.dtype):
+        assert system.dtype == dtype
 
 
 def test_partial_pbc():

--- a/python/metatensor_torch/tests/block.py
+++ b/python/metatensor_torch/tests/block.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import List, Optional, Tuple
 
@@ -329,9 +330,16 @@ def test_to():
 
 # This function only works in script mode, because `block.dtype` is always an `int`, and
 # `torch.dtype` is only an int in script mode.
-@torch.jit.script
-def check_dtype(block: TensorBlock, dtype: torch.dtype):
-    assert block.dtype == dtype
+if os.environ.get("PYTORCH_JIT") == "0":
+
+    def check_dtype(block: TensorBlock, dtype: torch.dtype):
+        pass
+
+else:
+
+    @torch.jit.script
+    def check_dtype(block: TensorBlock, dtype: torch.dtype):
+        assert block.dtype == dtype
 
 
 # define a wrapper class to make sure the types TorchScript uses for of all

--- a/python/metatensor_torch/tests/learn/module_map.py
+++ b/python/metatensor_torch/tests/learn/module_map.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import pytest
 import torch
@@ -127,6 +128,7 @@ def test_to_device(tensor, torch_script):
             assert label.device.type == device
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_torchscript(tensor):
     modules = []
     for key in tensor.keys:

--- a/python/metatensor_torch/tests/learn/torchscript.py
+++ b/python/metatensor_torch/tests/learn/torchscript.py
@@ -4,6 +4,7 @@ whether or not the module is jit scripted and 2) can be saved and loaded.
 """
 
 import io
+import os
 
 import pytest
 import torch
@@ -26,6 +27,11 @@ from metatensor.torch.learn.nn import (
 )
 
 from ._tests_utils import random_single_block_no_components_tensor_map
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript"
+)
 
 
 @pytest.fixture

--- a/python/metatensor_torch/tests/operations/abs.py
+++ b/python/metatensor_torch/tests/operations/abs.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -33,6 +34,7 @@ def test_abs():
         assert torch.all(block.values >= 0.0)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.sum_over_samples, buffer)

--- a/python/metatensor_torch/tests/operations/add.py
+++ b/python/metatensor_torch/tests/operations/add.py
@@ -43,6 +43,7 @@ def test_add(tensor_path):
     assert metatensor.torch.allclose(sum_tensor, metatensor.torch.multiply(tensor, 2))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.add, buffer)

--- a/python/metatensor_torch/tests/operations/allclose.py
+++ b/python/metatensor_torch/tests/operations/allclose.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -29,6 +30,7 @@ def test_allclose():
     metatensor.torch.allclose_block_raise(tensor.block(0), tensor.block(0))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.allclose, buffer)

--- a/python/metatensor_torch/tests/operations/block_from_array.py
+++ b/python/metatensor_torch/tests/operations/block_from_array.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import pytest
 import torch
@@ -20,6 +21,7 @@ def test_block_from_array(device):
         assert torch.equal(block.values, values)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.block_from_array, buffer)

--- a/python/metatensor_torch/tests/operations/contiguous.py
+++ b/python/metatensor_torch/tests/operations/contiguous.py
@@ -1,10 +1,13 @@
 import io
+import os
 
+import pytest
 import torch
 
 import metatensor.torch
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.is_contiguous, buffer)

--- a/python/metatensor_torch/tests/operations/detach.py
+++ b/python/metatensor_torch/tests/operations/detach.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -38,6 +39,7 @@ def test_detach():
         assert not block.values.requires_grad
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.detach, buffer)

--- a/python/metatensor_torch/tests/operations/divide.py
+++ b/python/metatensor_torch/tests/operations/divide.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -27,6 +28,7 @@ def test_divide():
     )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.divide, buffer)

--- a/python/metatensor_torch/tests/operations/dot.py
+++ b/python/metatensor_torch/tests/operations/dot.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -38,6 +39,7 @@ def test_dot():
         )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.dot, buffer)

--- a/python/metatensor_torch/tests/operations/drop_blocks.py
+++ b/python/metatensor_torch/tests/operations/drop_blocks.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -42,6 +43,7 @@ def test_drop_blocks():
     assert tensor.keys == expected_keys
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.drop_blocks, buffer)

--- a/python/metatensor_torch/tests/operations/empty_like.py
+++ b/python/metatensor_torch/tests/operations/empty_like.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -29,6 +30,7 @@ def test_empty_like():
     assert metatensor.torch.equal_metadata(empty_tensor, tensor)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.empty_like, buffer)

--- a/python/metatensor_torch/tests/operations/equal.py
+++ b/python/metatensor_torch/tests/operations/equal.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -28,6 +29,7 @@ def test_equal():
     metatensor.torch.equal_block_raise(tensor.block(0), tensor.block(0))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.equal, buffer)

--- a/python/metatensor_torch/tests/operations/equal_metadata.py
+++ b/python/metatensor_torch/tests/operations/equal_metadata.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -28,6 +29,7 @@ def test_equal_metadata():
     metatensor.torch.equal_metadata_block_raise(tensor.block(0), tensor.block(0))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.equal_metadata, buffer)

--- a/python/metatensor_torch/tests/operations/filter_blocks.py
+++ b/python/metatensor_torch/tests/operations/filter_blocks.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -42,6 +43,7 @@ def test_filter_blocks():
     assert tensor.keys == expected_keys
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.filter_blocks, buffer)

--- a/python/metatensor_torch/tests/operations/join.py
+++ b/python/metatensor_torch/tests/operations/join.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -40,6 +41,7 @@ def test_join():
     )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.join, buffer)

--- a/python/metatensor_torch/tests/operations/lstsq.py
+++ b/python/metatensor_torch/tests/operations/lstsq.py
@@ -1,5 +1,7 @@
 import io
+import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -50,6 +52,7 @@ def test_lstsq():
     assert metatensor.torch.equal(solution_tensor, expected_solution)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.lstsq, buffer)

--- a/python/metatensor_torch/tests/operations/manipulate_dimension.py
+++ b/python/metatensor_torch/tests/operations/manipulate_dimension.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -100,6 +101,7 @@ def test_rename():
     assert new_tensor.sample_names == ["system", "center_2"]
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.append_dimension, buffer)

--- a/python/metatensor_torch/tests/operations/multiply.py
+++ b/python/metatensor_torch/tests/operations/multiply.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -24,6 +25,7 @@ def test_multiply():
     assert torch.allclose(product_tensor.block(0).values, tensor.block(0).values ** 2)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.multiply, buffer)

--- a/python/metatensor_torch/tests/operations/one_hot.py
+++ b/python/metatensor_torch/tests/operations/one_hot.py
@@ -1,5 +1,7 @@
 import io
+import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -18,6 +20,7 @@ def test_one_hot():
     assert torch.all(one_hot_encoding == correct_encoding)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.one_hot, buffer)

--- a/python/metatensor_torch/tests/operations/ones_like.py
+++ b/python/metatensor_torch/tests/operations/ones_like.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -33,6 +34,7 @@ def test_ones_like():
         assert torch.all(block.values == 1)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.ones_like, buffer)

--- a/python/metatensor_torch/tests/operations/pow.py
+++ b/python/metatensor_torch/tests/operations/pow.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -26,6 +27,7 @@ def test_pow():
     )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.pow, buffer)

--- a/python/metatensor_torch/tests/operations/random_like.py
+++ b/python/metatensor_torch/tests/operations/random_like.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -29,6 +30,7 @@ def test_random_uniform_like():
     assert metatensor.torch.equal_metadata(random_tensor, tensor)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.random_uniform_like, buffer)

--- a/python/metatensor_torch/tests/operations/reduce_over_samples.py
+++ b/python/metatensor_torch/tests/operations/reduce_over_samples.py
@@ -83,6 +83,7 @@ def test_reduction_all_samples():
     assert torch.allclose(var_X[0].values, torch.var(X[0].values, correction=0, axis=0))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.sum_over_samples, buffer)

--- a/python/metatensor_torch/tests/operations/remove_gradients.py
+++ b/python/metatensor_torch/tests/operations/remove_gradients.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -35,6 +36,7 @@ def test_remove_gradients():
     assert tensor.block(0).gradients_list() == ["strain"]
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.remove_gradients, buffer)

--- a/python/metatensor_torch/tests/operations/requires_grad.py
+++ b/python/metatensor_torch/tests/operations/requires_grad.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -39,6 +40,7 @@ def test_requires_grad():
         assert not block.values.requires_grad
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.requires_grad, buffer)

--- a/python/metatensor_torch/tests/operations/slice.py
+++ b/python/metatensor_torch/tests/operations/slice.py
@@ -1,5 +1,7 @@
 import io
+import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -57,6 +59,7 @@ def test_slice_block():
     assert torch.equal(sliced_block_properties.values, torch.tensor([[1], [4]]))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.slice, buffer)

--- a/python/metatensor_torch/tests/operations/solve.py
+++ b/python/metatensor_torch/tests/operations/solve.py
@@ -1,5 +1,7 @@
 import io
+import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -50,6 +52,7 @@ def test_solve():
     assert metatensor.torch.equal(solution_tensor, expected_solution)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.solve, buffer)

--- a/python/metatensor_torch/tests/operations/sort.py
+++ b/python/metatensor_torch/tests/operations/sort.py
@@ -29,7 +29,8 @@ def test_sort():
     assert sorted_tensor._type().name() == "TensorMap"
 
 
-def test_save():
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
+def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.sort, buffer)
         buffer.seek(0)

--- a/python/metatensor_torch/tests/operations/split.py
+++ b/python/metatensor_torch/tests/operations/split.py
@@ -1,4 +1,5 @@
 import io
+import os
 
 import pytest
 import torch
@@ -118,6 +119,7 @@ def test_split_block():
     assert torch.equal(split_blocks_properties[1].values, torch.tensor([[2], [5]]))
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.split, buffer)

--- a/python/metatensor_torch/tests/operations/subtract.py
+++ b/python/metatensor_torch/tests/operations/subtract.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -27,6 +28,7 @@ def test_subtract():
     )
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.subtract, buffer)

--- a/python/metatensor_torch/tests/operations/unique_metadata.py
+++ b/python/metatensor_torch/tests/operations/unique_metadata.py
@@ -81,6 +81,7 @@ def test_unique_metadata_block(tensor):
     assert unique_labels.names == ["atom"]
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.unique_metadata, buffer)

--- a/python/metatensor_torch/tests/operations/zeros_like.py
+++ b/python/metatensor_torch/tests/operations/zeros_like.py
@@ -1,6 +1,7 @@
 import io
 import os
 
+import pytest
 import torch
 
 import metatensor.torch
@@ -33,6 +34,7 @@ def test_zeros_like():
         assert torch.all(block.values == 0)
 
 
+@pytest.mark.skipif(os.environ.get("PYTORCH_JIT") == "0", reason="requires TorchScript")
 def test_save_load():
     with io.BytesIO() as buffer:
         torch.jit.save(metatensor.torch.zeros_like, buffer)

--- a/python/metatensor_torch/tests/tensor.py
+++ b/python/metatensor_torch/tests/tensor.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List, Optional, Tuple, Union
 
 import pytest
@@ -553,9 +554,16 @@ def test_to(tensor):
 
 # This function only works in script mode, because `block.dtype` is always an `int`, and
 # `torch.dtype` is only an int in script mode.
-@torch.jit.script
-def check_dtype(tensor: TensorMap, dtype: torch.dtype):
-    assert tensor.dtype == dtype
+if os.environ.get("PYTORCH_JIT") == "0":
+
+    def check_dtype(tensor: TensorMap, dtype: torch.dtype):
+        pass
+
+else:
+
+    @torch.jit.script
+    def check_dtype(tensor: TensorMap, dtype: torch.dtype):
+        assert tensor.dtype == dtype
 
 
 # define a wrapper class to make sure the types TorchScript uses for of all


### PR DESCRIPTION
With #903, we can now actually check the type of TorchScript objects!

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
