### PR TITLE
Add support for Torch 2.7

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -101,7 +101,7 @@ jobs:
     name: ${{ matrix.name }} (torch v${{ matrix.torch-version }})
     strategy:
       matrix:
-        torch-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6']
+        torch-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
         arch: ['arm64', 'x86_64']
         os: ['ubuntu-22.04', 'ubuntu-22.04-arm', 'macos-13', 'macos-14', 'windows-2022']
         exclude:
@@ -116,6 +116,7 @@ jobs:
           - {os: macos-13, arch: x86_64, torch-version: '2.4'}
           - {os: macos-13, arch: x86_64, torch-version: '2.5'}
           - {os: macos-13, arch: x86_64, torch-version: '2.6'}
+          - {os: macos-13, arch: x86_64, torch-version: '2.7'}
         include:
           # add `cibw-arch` and `rust-target` to the different configurations
           - name: x86_64 Linux
@@ -150,15 +151,7 @@ jobs:
           - {torch-version: '2.4', cibw-python: 'cp312-*'}
           - {torch-version: '2.5', cibw-python: 'cp312-*'}
           - {torch-version: '2.6', cibw-python: 'cp312-*'}
-          # set the right manylinux image to use
-          - {torch-version: '2.1', manylinux-version: "2014"}
-          - {torch-version: '2.2', manylinux-version: "2014"}
-          - {torch-version: '2.3', manylinux-version: "2014"}
-          - {torch-version: '2.4', manylinux-version: "2014"}
-          - {torch-version: '2.5', manylinux-version: "2014"}
-          # only torch >+ 2.6 on arm64-linux needs the newer manylinux
-          - {torch-version: '2.6', arch: arm64, manylinux-version: "_2_28"}
-          - {torch-version: '2.6', arch: x86_64, manylinux-version: "2014"}
+          - {torch-version: '2.7', cibw-python: 'cp312-*'}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,8 +175,8 @@ jobs:
         if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-22.04-arm'
         run: |
           docker buildx build \
-              -t rustc-manylinux${{ matrix.manylinux-version }}_${{ matrix.cibw-arch }} \
-              python/scripts/rustc-manylinux${{ matrix.manylinux-version }}_${{ matrix.cibw-arch }}
+              -t rustc-manylinux_2_28_${{ matrix.cibw-arch }} \
+              python/scripts/rustc-manylinux_2_28_${{ matrix.cibw-arch }}
 
       - name: build metatensor-torch wheel
         run: python -m cibuildwheel python/metatensor_torch
@@ -192,8 +185,8 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.cibw-arch }}
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_MANYLINUX_X86_64_IMAGE: rustc-manylinux${{ matrix.manylinux-version }}_x86_64
-          CIBW_MANYLINUX_AARCH64_IMAGE: rustc-manylinux${{ matrix.manylinux-version }}_aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: rustc-manylinux_2_28_x86_64
+          CIBW_MANYLINUX_AARCH64_IMAGE: rustc-manylinux_2_28_aarch64
           # METATENSOR_NO_LOCAL_DEPS is set to 1 when building a tag of
           # metatensor-torch, which will force to use the version of
           # metatensor-core already released on PyPI. Otherwise, this will use
@@ -449,13 +442,13 @@ jobs:
         include:
           - os: ubuntu-22.04
             rust-target: x86_64-unknown-linux-gnu
-            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.6.0%2Bcpu.zip
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.7.0%2Bcpu.zip
           - os: macos-14
             rust-target: aarch64-apple-darwin
-            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.6.0.zip
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-macos-arm64-2.7.0.zip
           - os: windows-2022
             rust-target: x86_64-pc-windows-msvc
-            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.6.0%2Bcpu.zip
+            libtorch-url: https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-2.7.0%2Bcpu.zip
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,16 +23,16 @@ jobs:
             numpy-version-pin: "<2.0"
           - os: ubuntu-22.04
             python-version: "3.9"
-            torch-version: "2.6"
+            torch-version: "2.7"
           - os: ubuntu-22.04
             python-version: "3.13"
-            torch-version: "2.6"
+            torch-version: "2.7"
           - os: macos-14
             python-version: "3.13"
-            torch-version: "2.6"
+            torch-version: "2.7"
           - os: windows-2022
             python-version: "3.13"
-            torch-version: "2.6"
+            torch-version: "2.7"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            torch-version: "2.6"
+            torch-version: "2.7"
             python-version: "3.13"
             cargo-test-flags: --release
             do-valgrind: true
@@ -32,12 +32,12 @@ jobs:
             cxx-flags: -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer -g
 
           - os: macos-14
-            torch-version: "2.6"
+            torch-version: "2.7"
             python-version: "3.13"
             cargo-test-flags: --release
 
           - os: windows-2022
-            torch-version: "2.6"
+            torch-version: "2.7"
             python-version: "3.13"
             cargo-test-flags: --release
     steps:

--- a/python/scripts/rustc-manylinux2014_aarch64/Dockerfile
+++ b/python/scripts/rustc-manylinux2014_aarch64/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
 # Download rustup-init asn install
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.86
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="aarch64-unknown-linux-gnu"

--- a/python/scripts/rustc-manylinux2014_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux2014_x86_64/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
 # Download rustup-init asn install
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.86
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"

--- a/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
 # Download rustup-init asn install
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.86
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="aarch64-unknown-linux-gnu"

--- a/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
@@ -5,7 +5,7 @@ RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
 # Download rustup-init asn install
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.86
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"

--- a/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
@@ -1,0 +1,11 @@
+# Use manylinux docker image as a base
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+RUN yum install git -y
+RUN git config --global --add safe.directory /code
+
+# Download rustup-init asn install
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.75
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ description = Run the tests of the metatensor-core Python package
 deps =
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
     {[testenv]testing_deps}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
 
 changedir = python/metatensor_core
 commands =
@@ -99,7 +99,7 @@ deps =
     {[testenv]packaging_deps}
     {[testenv]testing_deps}
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
 
 changedir = python/metatensor_operations
 commands =
@@ -136,7 +136,7 @@ description =
 deps =
     {[testenv]packaging_deps}
     {[testenv]testing_deps}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
 
     ; used for checking equivariance
@@ -163,7 +163,7 @@ deps =
     {[testenv]testing_deps}
 
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
     ase
 
 changedir = python/metatensor_torch
@@ -192,7 +192,7 @@ deps =
     {[testenv]testing_deps}
 
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
     ase
 
 setenv =
@@ -256,7 +256,7 @@ deps =
 
     # required for autodoc
     numpy {env:METATENSOR_TESTS_NUMPY_VERSION_PIN}
-    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.6.*}
+    torch=={env:METATENSOR_TESTS_TORCH_VERSION:2.7.*}
 
     # required for examples
     ase


### PR DESCRIPTION
The biggest change is that we will now have manylinux_2_28 wheels instead of manylinux2014 wheels. These should still be compatible with most linux distributions used nowadays.


# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
