### PR TITLE
Release metatensor-operations v0.3.3 and metatensor-learn v0.3.2

### DIFF
--- a/docs/src/learn/reference/index.rst
+++ b/docs/src/learn/reference/index.rst
@@ -12,6 +12,7 @@ API reference
     :tag-prefix: metatensor-learn-v
     :url-suffix: learn/reference/index.html
 
+    .. version:: 0.3.2
     .. version:: 0.3.1
     .. version:: 0.3.0
     .. version:: 0.2.3

--- a/docs/src/operations/reference/index.rst
+++ b/docs/src/operations/reference/index.rst
@@ -13,6 +13,7 @@ API reference
     :tag-prefix: metatensor-operations-v
     :url-suffix: operations/reference/index.html
 
+    .. version:: 0.3.3
     .. version:: 0.3.2
     .. version:: 0.3.1
     .. version:: 0.3.0

--- a/python/metatensor_learn/CHANGELOG.md
+++ b/python/metatensor_learn/CHANGELOG.md
@@ -17,6 +17,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.3.2](https://github.com/metatensor/metatensor/releases/tag/metatensor-learn-v0.3.2) - 2025-04-25
+
+- Make the code compatible with metatensor-torch v0.7.6
+
 ## [Version 0.3.1](https://github.com/metatensor/metatensor/releases/tag/metatensor-learn-v0.3.1) - 2025-02-03
 
 ### Fixed

--- a/python/metatensor_learn/setup.py
+++ b/python/metatensor_learn/setup.py
@@ -13,7 +13,7 @@ METATENSOR_OPERATIONS = os.path.realpath(
     os.path.join(ROOT, "..", "metatensor_operations")
 )
 
-METATENSOR_LEARN_VERSION = "0.3.1"
+METATENSOR_LEARN_VERSION = "0.3.2"
 
 
 class bdist_egg_disabled(bdist_egg):

--- a/python/metatensor_operations/CHANGELOG.md
+++ b/python/metatensor_operations/CHANGELOG.md
@@ -17,6 +17,16 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.3.3](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.3.3) - 2025-04-25
+
+### Fixed
+
+- Changed the implementation of `std_over_samples` and `var_over_samples` to
+  reduce numerical noise issues when working with float32 (#908)
+- Make sure the filtered `TensorMap` has keys in the same order as the filter in
+  `filter_blocks` (#885)
+- Make the code compatible with metatensor-torch v0.7.6
+
 ## [Version 0.3.2](https://github.com/metatensor/metatensor/releases/tag/metatensor-operations-v0.3.2) - 2025-02-18
 
 ### Fixed

--- a/python/metatensor_operations/setup.py
+++ b/python/metatensor_operations/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.sdist import sdist
 ROOT = os.path.realpath(os.path.dirname(__file__))
 METATENSOR_CORE = os.path.realpath(os.path.join(ROOT, "..", "metatensor_core"))
 
-METATENSOR_OPERATIONS_VERSION = "0.3.2"
+METATENSOR_OPERATIONS_VERSION = "0.3.3"
 
 
 class bdist_egg_disabled(bdist_egg):


### PR DESCRIPTION
We need a new release to be compatible with metatensor-torch v0.7.6 due to #906