### PR TITLE
Enable verbose output when building wheels

### DIFF
--- a/python/metatensor_core/setup.py
+++ b/python/metatensor_core/setup.py
@@ -53,6 +53,7 @@ class cmake_ext(build_ext):
         )
 
         cmake_options = [
+            "-DCMAKE_VERBOSE_MAKEFILE=ON",
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
             f"-DMETATENSOR_CORE_SOURCE_DIR={METATENSOR_CORE_SRC}",
             "-DCMAKE_INSTALL_LIBDIR=lib",

--- a/python/metatensor_torch/setup.py
+++ b/python/metatensor_torch/setup.py
@@ -70,6 +70,7 @@ class cmake_ext(build_ext):
         )
 
         cmake_options = [
+            "-DCMAKE_VERBOSE_MAKEFILE=ON",
             f"-DCMAKE_BUILD_TYPE={METATENSOR_BUILD_TYPE}",
             f"-DCMAKE_INSTALL_PREFIX={cmake_install_prefix}",
             "-DCMAKE_INSTALL_LIBDIR=lib",

--- a/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_aarch64/Dockerfile
@@ -9,3 +9,10 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="aarch64-unknown-linux-gnu"
+
+# Install an older C++ compiler. The default compiler (gcc-14) introduces calls
+# to `__cxa_call_terminate` which is not available in ubuntu-22.04 libstdc++
+ARG DEVTOOLSET_VERSION=11
+RUN yum install -y gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH

--- a/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
+++ b/python/scripts/rustc-manylinux_2_28_x86_64/Dockerfile
@@ -9,3 +9,10 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-too
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"
+
+# Install an older C++ compiler. The default compiler (gcc-14) introduces calls
+# to `__cxa_call_terminate` which is not available in ubuntu-22.04 libstdc++
+ARG DEVTOOLSET_VERSION=11
+RUN yum install -y gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
+ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
I need this now to debug why `libmetatensor_torch.so` contains its own copy of `__cxa_call_terminate` while metatomic-torch does not, but it will also be useful long term if someone has issues building the wheels.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
