### PR TITLE
Prevent segmentation fault for out-of-bound index in Labels.insert

### DIFF
--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -284,6 +284,13 @@ Labels LabelsHolder::append(std::string name, torch::Tensor values) const {
 
 
 Labels LabelsHolder::insert(int64_t index, std::string name, torch::Tensor values) const {
+    if (index < 0 or index > this->size()) {
+        C10_THROW_ERROR(
+            IndexError,
+            "index " + std::to_string(index) + " is out of bounds"
+        );
+    }
+
     auto new_names = this->names();
 
     auto it = std::begin(new_names) + index;

--- a/metatensor-torch/src/labels.cpp
+++ b/metatensor-torch/src/labels.cpp
@@ -284,7 +284,7 @@ Labels LabelsHolder::append(std::string name, torch::Tensor values) const {
 
 
 Labels LabelsHolder::insert(int64_t index, std::string name, torch::Tensor values) const {
-    if (index < 0 or index > this->size()) {
+    if (index < 0 || index > this->size()) {
         C10_THROW_ERROR(
             IndexError,
             "index " + std::to_string(index) + " is out of bounds"

--- a/python/metatensor_core/tests/labels.py
+++ b/python/metatensor_core/tests/labels.py
@@ -126,6 +126,9 @@ def test_dimensions_manipulation():
     with pytest.raises(ValueError, match="`values` must be a 1D array"):
         label.insert(0, name="bar", values=np.array([[10]]))
 
+    with pytest.raises(IndexError, match="index 42 is out of bounds"):
+        label.insert(42, name="bar", values=np.array([42]))
+
     # Labels.append
     new_label = label.append(name="bar", values=np.array([10]))
     assert new_label.names == ["foo", "bar"]

--- a/python/metatensor_torch/tests/labels.py
+++ b/python/metatensor_torch/tests/labels.py
@@ -470,6 +470,9 @@ def test_dimensions_manipulation():
     with pytest.raises(ValueError, match="`values` must be a 1D tensor"):
         label.insert(0, name="bar", values=torch.tensor([[10]]))
 
+    with pytest.raises(IndexError, match="index 42 is out of bounds"):
+        label.insert(42, name="bar", values=torch.tensor([42]))
+
     # Labels.append
     new_label = label.append(name="bar", values=torch.tensor([10]))
     assert new_label.names == ["foo", "bar"]


### PR DESCRIPTION
Using an out of bound index in `Labels.insert` with `metatensor.torch` leads to a segmentation fault. This PR adds a bound check to `LabelsHolder::insert` to get a similar error to the one obtained with `metatensor`.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
