### PR TITLE
Handle empty vector before dispatchiong to concatenate when inserting a Label dimension

### DIFF
--- a/python/metatensor_operations/metatensor/operations/_manipulate_dimension.py
+++ b/python/metatensor_operations/metatensor/operations/_manipulate_dimension.py
@@ -12,6 +12,13 @@ def _check_axis(axis: str):
         )
 
 
+def _concat(values: Array, n: int, axis: int):
+    print(">>> DBG", values, values.shape, n)
+    if n == 0:
+        return _dispatch.empty_like(values, shape=(0,))
+    return _dispatch.concatenate([values] * n, axis=axis)
+
+
 @torch_jit_script
 def insert_dimension(
     tensor: TensorMap,
@@ -78,7 +85,7 @@ def insert_dimension(
 
     if axis == "keys":
         if values_was_int:
-            label_values = _dispatch.concatenate([values] * len(keys), axis=0)
+            label_values = _concat(values, len(keys), axis=0)
 
         keys = keys.insert(index=index, name=name, values=label_values)
 
@@ -89,13 +96,13 @@ def insert_dimension(
 
         if axis == "samples":
             if values_was_int:
-                label_values = _dispatch.concatenate([values] * len(samples), axis=0)
+                label_values = _concat(values, len(samples), axis=0)
 
             samples = samples.insert(index=index, name=name, values=label_values)
 
         elif axis == "properties":
             if values_was_int:
-                label_values = _dispatch.concatenate([values] * len(properties), axis=0)
+                label_values = _concat(values, len(properties), axis=0)
 
             properties = properties.insert(index=index, name=name, values=label_values)
 

--- a/python/metatensor_operations/metatensor/operations/_manipulate_dimension.py
+++ b/python/metatensor_operations/metatensor/operations/_manipulate_dimension.py
@@ -13,7 +13,6 @@ def _check_axis(axis: str):
 
 
 def _concat(values: Array, n: int, axis: int):
-    print(">>> DBG", values, values.shape, n)
     if n == 0:
         return _dispatch.empty_like(values, shape=(0,))
     return _dispatch.concatenate([values] * n, axis=axis)

--- a/python/metatensor_torch/tests/operations/manipulate_dimension.py
+++ b/python/metatensor_torch/tests/operations/manipulate_dimension.py
@@ -67,6 +67,34 @@ def test_insert():
     assert new_tensor.property_names == ["new", "l", "n_1", "n_2"]
 
 
+def test_insert_dimension_on_empty_labels():
+    """https://github.com/metatensor/metatensor/issues/600"""
+
+    s = mts.Labels.empty(["a", "b"])
+    k = mts.Labels(names=["key"], values=torch.tensor([[0], [1]]))
+    b = mts.TensorBlock(
+        samples=s,
+        components=[],
+        properties=mts.Labels.single(),
+        values=torch.zeros((len(s), 1)),
+    )
+
+    t = mts.TensorMap(
+        keys=k,
+        blocks=[b, b],
+    )
+
+    for block in t:
+        assert block.samples.names == ["a", "b"]
+        assert block.samples.values.shape == (len(s), 2)
+
+    tt = mts.insert_dimension(t, axis="samples", name="d", index=2, values=42)
+
+    for block in tt:
+        assert block.samples.names == ["a", "b", "d"]
+        assert block.samples.values.shape == (len(s), 3)
+
+
 def test_permute():
     tensor = get_tensor_map()
 

--- a/python/metatensor_torch/tests/operations/manipulate_dimension.py
+++ b/python/metatensor_torch/tests/operations/manipulate_dimension.py
@@ -94,6 +94,16 @@ def test_insert_dimension_on_empty_labels():
         assert block.samples.names == ["a", "b", "d"]
         assert block.samples.values.shape == (len(s), 3)
 
+    tt = mts.insert_dimension(t, axis="properties", name="d", index=0, values=42)
+
+    for block in tt:
+        assert block.properties.names == ["d", "_"]
+        assert block.properties.values.shape == (1, 2)
+
+    # RuntimeError from the TorchScript interpreter
+    with pytest.raises(RuntimeError, match="index 42 is out of bounds"):
+        mts.insert_dimension(t, axis="samples", name="d", index=42, values=42)
+
 
 def test_permute():
     tensor = get_tensor_map()

--- a/scripts/git-version-info.py
+++ b/scripts/git-version-info.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 
+
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 
 

--- a/scripts/git-version-info.py
+++ b/scripts/git-version-info.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 import tempfile
 
-
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -74,7 +73,7 @@ def n_commits_since_last_tag(tag_prefix):
 
 def git_hash_all_code():
     # make sure the index is up to date before doing `git diff-index`
-    run_subprocess(["git", "update-index", "-q", "--really-refresh"])
+    run_subprocess(["git", "update-index", "-q", "--really-refresh"], check=False)
 
     output = subprocess.run(
         ["git", "diff-index", "--quiet", "HEAD", "--"],

--- a/scripts/git-version-info.py
+++ b/scripts/git-version-info.py
@@ -73,7 +73,7 @@ def n_commits_since_last_tag(tag_prefix):
 
 def git_hash_all_code():
     # make sure the index is up to date before doing `git diff-index`
-    run_subprocess(["git", "update-index", "-q", "--really-refresh"], check=False)
+    run_subprocess(["git", "update-index", "-q", "--really-refresh"])
 
     output = subprocess.run(
         ["git", "diff-index", "--quiet", "HEAD", "--"],


### PR DESCRIPTION
Close #600.

This PR adds a check that arrays are non-empty before dispatching to concatenate. Otherwise, returns an empty tensor with the same type as values.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
