### PR TITLE
Print where metatensor(-torch) was found when using find_package in CMake

### DIFF
--- a/metatensor-core/cmake/metatensor-config.in.cmake
+++ b/metatensor-core/cmake/metatensor-config.in.cmake
@@ -78,3 +78,10 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18")
         add_library(metatensor ALIAS metatensor::static)
     endif()
 endif()
+
+
+if (@BUILD_SHARED_LIBS@)
+    find_package_handle_standard_args(metatensor DEFAULT_MSG METATENSOR_SHARED_LOCATION METATENSOR_INCLUDE)
+else()
+    find_package_handle_standard_args(metatensor DEFAULT_MSG METATENSOR_STATIC_LOCATION METATENSOR_INCLUDE)
+endif()

--- a/metatensor-torch/cmake/metatensor_torch-config.in.cmake
+++ b/metatensor-torch/cmake/metatensor_torch-config.in.cmake
@@ -21,3 +21,10 @@ if (NOT "${BUILD_TORCH_MINOR}" STREQUAL "${Torch_VERSION_MINOR}")
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/metatensor_torch-targets.cmake)
+
+get_target_property(metatensor_torch_configs metatensor_torch IMPORTED_CONFIGURATIONS)
+foreach(config ${metatensor_torch_configs})
+    get_target_property(metatensor_torch_library metatensor_torch IMPORTED_LOCATION_${config})
+endforeach()
+
+find_package_handle_standard_args(metatensor_torch DEFAULT_MSG metatensor_torch_library)

--- a/metatensor-torch/tests/utils/mod.rs
+++ b/metatensor-torch/tests/utils/mod.rs
@@ -84,7 +84,7 @@ pub fn setup_pytorch(build_dir: PathBuf) -> PathBuf {
         .expect("failed to run python");
     assert!(status.success(), "failed to run `python -m pip install --upgrade pip`");
 
-    let torch_version = std::env::var("METATENSOR_TESTS_TORCH_VERSION").unwrap_or("2.6".into());
+    let torch_version = std::env::var("METATENSOR_TESTS_TORCH_VERSION").unwrap_or("2.7".into());
     let status = Command::new(&python)
         .arg("-m")
         .arg("pip")


### PR DESCRIPTION
This should make it easier to debug downstream users pulling the wrong version.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
