### PR TITLE
Add `drop_empty_blocks` operation

### DIFF
--- a/docs/src/operations/reference/manipulation/drop-blocks.rst
+++ b/docs/src/operations/reference/manipulation/drop-blocks.rst
@@ -2,3 +2,5 @@ drop_blocks
 ===========
 
 .. autofunction:: metatensor.drop_blocks
+
+.. autofunction:: metatensor.drop_empty_blocks

--- a/python/metatensor_operations/metatensor/operations/__init__.py
+++ b/python/metatensor_operations/metatensor/operations/__init__.py
@@ -21,7 +21,7 @@ from ._checks import (  # noqa: F401
 from ._detach import detach, detach_block  # noqa: F401
 from ._divide import divide  # noqa: F401
 from ._dot import dot  # noqa: F401
-from ._drop_blocks import drop_blocks  # noqa: F401
+from ._drop_blocks import drop_blocks, drop_empty_blocks  # noqa: F401
 from ._empty_like import empty_like, empty_like_block  # noqa: F401
 from ._equal import equal, equal_block, equal_block_raise, equal_raise  # noqa: F401
 from ._equal_metadata import (  # noqa: F401

--- a/python/metatensor_operations/metatensor/operations/_drop_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/_drop_blocks.py
@@ -94,3 +94,78 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
         )
 
     return TensorMap(keys=new_keys, blocks=new_blocks)
+
+
+@torch_jit_script
+def drop_empty_blocks(tensor: TensorMap, copy: bool = False) -> TensorMap:
+    """
+    Drop every blocks in a :py:class: `TensorMap` with any 0-length dimension.
+
+    :param tensor: the :py:class:`TensorMap` to drop empty blocks from.
+
+    :param copy: if :py:obj:`True`, the returned :py:class:`TensorMap` is constructed by
+        copying the blocks from the input `tensor`. If :py:obj:`False` (default), the
+        values of the blocks in the output :py:class:`TensorMap` reference the same data
+        as the input `tensor`. The latter can be useful for limiting memory usage, but
+        should be used with caution when manipulating the underlying data.
+    """
+    # Check arg types
+    if not torch_jit_is_scripting():
+        if not isinstance_metatensor(tensor, "TensorMap"):
+            raise TypeError(
+                f"`tensor` must be a metatensor TensorMap, not {type(tensor)}"
+            )
+
+        if not isinstance(copy, bool):
+            raise TypeError(f"`copy` must be a boolean, not {type(copy)}")
+
+    # Create a new TensorMap
+    new_blocks: List[TensorBlock] = []
+    new_keys_values = []
+
+    for key, block in tensor.items():
+        # Check if the block has any 0-length dimension
+        if any(dim == 0 for dim in block.values.shape):
+            continue
+
+        new_keys_values.append(key.values)
+
+        if copy:
+            new_blocks.append(block.copy())
+        else:
+            # just increase the reference count on everything
+            new_block = TensorBlock(
+                values=block.values,
+                samples=block.samples,
+                components=block.components,
+                properties=block.properties,
+            )
+
+            for parameter, gradient in block.gradients():
+                if len(gradient.gradients_list()) != 0:
+                    raise NotImplementedError(
+                        "gradients of gradients are not supported"
+                    )
+
+                new_block.add_gradient(
+                    parameter=parameter,
+                    gradient=TensorBlock(
+                        values=gradient.values,
+                        samples=gradient.samples,
+                        components=gradient.components,
+                        properties=new_block.properties,
+                    ),
+                )
+
+            new_blocks.append(new_block)
+
+    if len(new_keys_values) != 0:
+        new_keys = Labels(tensor.keys.names, _dispatch.stack(new_keys_values, 0))
+    else:
+        new_keys = Labels(
+            names=tensor.keys.names,
+            values=_dispatch.empty_like(
+                tensor.keys.values, (0, len(tensor.keys.names))
+            ),
+        )
+    return TensorMap(keys=new_keys, blocks=new_blocks)

--- a/python/metatensor_operations/metatensor/operations/_drop_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/_drop_blocks.py
@@ -99,7 +99,8 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
 @torch_jit_script
 def drop_empty_blocks(tensor: TensorMap, copy: bool = False) -> TensorMap:
     """
-    Drop every blocks in a :py:class:`TensorMap` with any 0-length dimension.
+    Drop any block in a :py:class:`TensorMap` with an empty set of samples, 
+    components or properties.
 
     :param tensor: the :py:class:`TensorMap` to drop empty blocks from.
 

--- a/python/metatensor_operations/metatensor/operations/_drop_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/_drop_blocks.py
@@ -99,7 +99,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
 @torch_jit_script
 def drop_empty_blocks(tensor: TensorMap, copy: bool = False) -> TensorMap:
     """
-    Drop every blocks in a :py:class: `TensorMap` with any 0-length dimension.
+    Drop every blocks in a :py:class:`TensorMap` with any 0-length dimension.
 
     :param tensor: the :py:class:`TensorMap` to drop empty blocks from.
 

--- a/python/metatensor_operations/metatensor/operations/_drop_blocks.py
+++ b/python/metatensor_operations/metatensor/operations/_drop_blocks.py
@@ -99,7 +99,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
 @torch_jit_script
 def drop_empty_blocks(tensor: TensorMap, copy: bool = False) -> TensorMap:
     """
-    Drop any block in a :py:class:`TensorMap` with an empty set of samples, 
+    Drop any block in a :py:class:`TensorMap` with an empty set of samples,
     components or properties.
 
     :param tensor: the :py:class:`TensorMap` to drop empty blocks from.

--- a/python/metatensor_operations/tests/drop_blocks.py
+++ b/python/metatensor_operations/tests/drop_blocks.py
@@ -27,7 +27,8 @@ def test_drop_blocks_empty_tensor():
 def test_drop_block_with_an_empty_dimension():
     """
     Define a TensorMap in which block_2 has a zero-length dimension.
-    Assert then that calling drop_empty_blocks() removes block_2 from the resulting TensorMap.
+    Assert then that calling drop_empty_blocks() removes block_2 from
+    the resulting TensorMap.
     """
     block_1 = TensorBlock(
         values=np.full((5, 3), 2.0),
@@ -80,7 +81,7 @@ def test_drop_empty_blocks_in_empty_tensor():
 
 
 def test_drop_empty_blocks_on_tensor_with_no_empty_blocks():
-    """ 
+    """
     Define a TensorMap in which no block has a zero-length dimension.
     Assert than that calling drop_empty_blocks() leaves all blocks intact.
     """
@@ -103,10 +104,6 @@ def test_drop_empty_blocks_on_tensor_with_no_empty_blocks():
         properties=Labels.range("property", 6),
     )
     keys = Labels(names=["id"], values=np.array([[0], [1], [2]]))
-
-    bkp_block_1 = block_1.copy()
-    bkp_block_2 = block_2.copy()
-    bkp_block_3 = block_3.copy()
 
     # Create the TensorMap
     tensor = TensorMap(keys=keys, blocks=[block_1, block_2, block_3])

--- a/python/metatensor_operations/tests/drop_blocks.py
+++ b/python/metatensor_operations/tests/drop_blocks.py
@@ -114,6 +114,9 @@ def test_drop_empty_blocks_on_tensor_with_no_empty_blocks():
 
 
 def test_drop_all(tensor):
+    """
+    Test that all the blocks are effectively dropped
+    """
     tensor = mts.drop_blocks(tensor, tensor.keys)
     empty_tensor = TensorMap(keys=Labels.empty(tensor.keys.names), blocks=[])
     assert mts.equal(tensor, empty_tensor)


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
In this case, a method called drop_empty_blocks has been implemented, whose function is to drop all blocks contained in a TensorMap that have any of their dimensions equal to 0.

fix #786

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)? 

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
