### PR TITLE
CMake: include CMake module FindPackageHandleStandardArgs as needed

### DIFF
--- a/metatensor-core/cmake/metatensor-config.in.cmake
+++ b/metatensor-core/cmake/metatensor-config.in.cmake
@@ -2,6 +2,8 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+include(FindPackageHandleStandardArgs)
+
 if(metatensor_FOUND)
     return()
 endif()

--- a/metatensor-torch/cmake/metatensor_torch-config.in.cmake
+++ b/metatensor-torch/cmake/metatensor_torch-config.in.cmake
@@ -1,4 +1,5 @@
 include(CMakeFindDependencyMacro)
+include(FindPackageHandleStandardArgs)
 
 # use the same version for metatensor-core as the main CMakeLists.txt
 set(REQUIRED_METATENSOR_VERSION @REQUIRED_METATENSOR_VERSION@)


### PR DESCRIPTION
Fixes #953, a build issue found in https://github.com/spack/spack-packages/pull/145:

> ```py
>  CMake Error at lib/cmake/metatensor/metatensor-config.cmake:108 (find_package_handle_standard_args):
>    Unknown CMake command "find_package_handle_standard_args".
>  Call Stack (most recent call first):
>    CMakeLists.txt:28 (find_package)
> ```

Add
```cmake
include(FindPackageHandleStandardArgs)
```
like https://github.com/metatensor/metatensor/blob/39f294437ae21a89f7ebfb8c37b3e4ef9725626d/metatensor-torch/cmake/FindCUDNN.cmake#L15 does, for example.

See https://github.com/pistacheio/pistache/pull/598/files for an equivalent fix.