### PR TITLE
Make sure to always build wheels in release mode

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -87,6 +87,7 @@ jobs:
           CIBW_ENVIRONMENT: >
             METATENSOR_NO_LOCAL_DEPS=1
             MACOSX_DEPLOYMENT_TARGET=11
+            METATENSOR_BUILD_TYPE=release
 
       - name: check wheels with twine
         run: twine check wheelhouse/*
@@ -202,6 +203,7 @@ jobs:
             METATENSOR_TORCH_BUILD_WITH_TORCH_VERSION=${{ matrix.torch-version }}.*
             PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
             MACOSX_DEPLOYMENT_TARGET=11
+            METATENSOR_BUILD_TYPE=release
           # do not complain for missing libtorch.so or libmetatensor.so
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
             delocate-wheel --ignore-missing-dependencies --require-archs {delocate_archs} -w {dest_dir} -v {wheel}

--- a/python/metatensor_core/setup.py
+++ b/python/metatensor_core/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.sdist import sdist
 
 ROOT = os.path.realpath(os.path.dirname(__file__))
 
-METATENSOR_BUILD_TYPE = os.environ.get("METATENSOR_BUILD_TYPE", "debug")
+METATENSOR_BUILD_TYPE = os.environ.get("METATENSOR_BUILD_TYPE", "release")
 if METATENSOR_BUILD_TYPE not in ["debug", "release"]:
     raise Exception(
         f"invalid build type passed: '{METATENSOR_BUILD_TYPE}', "


### PR DESCRIPTION
I flipped the default for metatensor-core to `debug` in setup.py in #820 for debugging, and forgot to change it back. 

So we now have two layers of protection: the default build type from Python is now back to `release`, and we force it to be `release` when building wheels in CI.

Not sure if there is something else we could do to improve the situation. It seems that detecting whether a given binary was built in release or debug mode is non trivial.
 
# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
